### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,10 @@ module.exports = {
   organizationName: "blitzjs", // Usually your GitHub org/user name.
   projectName: "blitzjs.com", // Usually your repo name.
   themeConfig: {
+    algolia: {
+      apiKey: 'c4db860ae4162be48d4c867e33edcaa2',
+      indexName: 'blitzjs',
+    },
     navbar: {
       title: "Blitz JS ⚡️",
       logo: {


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.