### PR TITLE
add vercel to footer, swizzle Footer component

### DIFF
--- a/src/theme/Footer/footer_styles.css
+++ b/src/theme/Footer/footer_styles.css
@@ -1,0 +1,3 @@
+.footer-vercel a {
+  color: white;
+}

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
+import classnames from "classnames";
+
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import styles from "./styles.module.css";
+import "./footer_styles.css";
+
+function FooterLink({ to, href, label, ...props }) {
+  const toUrl = useBaseUrl(to);
+  return (
+    <Link
+      className="footer__link-item"
+      {...(href
+        ? {
+            target: "_blank",
+            rel: "noopener noreferrer",
+            href,
+          }
+        : {
+            to: toUrl,
+          })}
+      {...props}
+    >
+      {label}
+    </Link>
+  );
+}
+
+const FooterLogo = ({ url, alt }) => (
+  <img className="footer__logo" alt={alt} src={url} />
+);
+
+function Footer() {
+  const context = useDocusaurusContext();
+  const { siteConfig = {} } = context;
+  const { themeConfig = {} } = siteConfig;
+  const { footer } = themeConfig;
+
+  const { copyright, links = [], logo = {} } = footer || {};
+  const logoUrl = useBaseUrl(logo.src);
+
+  if (!footer) {
+    return null;
+  }
+
+  return (
+    <footer
+      className={classnames("footer", {
+        "footer--dark": footer.style === "dark",
+      })}
+    >
+      <div className="container">
+        {links && links.length > 0 && (
+          <div className="row footer__links">
+            {links.map((linkItem, i) => (
+              <div key={i} className="col footer__col">
+                {linkItem.title != null ? (
+                  <h4 className="footer__title">{linkItem.title}</h4>
+                ) : null}
+                {linkItem.items != null &&
+                Array.isArray(linkItem.items) &&
+                linkItem.items.length > 0 ? (
+                  <ul className="footer__items">
+                    {linkItem.items.map((item, key) =>
+                      item.html ? (
+                        <li
+                          key={key}
+                          className="footer__item"
+                          dangerouslySetInnerHTML={{
+                            __html: item.html,
+                          }}
+                        />
+                      ) : (
+                        <li key={item.href || item.to} className="footer__item">
+                          <FooterLink {...item} />
+                        </li>
+                      )
+                    )}
+                  </ul>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+        {(logo || copyright) && (
+          <div className="text--center">
+            <div className="footer__links footer-vercel">
+              <a href="https://vercel.com/?utm_source=blitzjs">
+                Hosted on⠀
+                <svg
+                  width="15"
+                  height="12"
+                  viewBox="0 0 116 100"
+                  fill="#fff"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M57.5 0L115 100H0L57.5 0z"
+                  />
+                </svg>
+                Vercel
+              </a>
+            </div>
+            {logo && logo.src && (
+              <div className="margin-bottom--sm">
+                {logo.href ? (
+                  <a
+                    href={logo.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.footerLogoLink}
+                  >
+                    <FooterLogo alt={logo.alt} url={logoUrl} />
+                  </a>
+                ) : (
+                  <FooterLogo alt={logo.alt} url={logoUrl} />
+                )}
+              </div>
+            )}
+
+            <div
+              dangerouslySetInnerHTML={{
+                __html: copyright,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -92,8 +92,8 @@ function Footer() {
           </div>
         )}
         {(logo || copyright) && (
-          <div className="text--center">
-            <div className="footer__links footer-vercel">
+          <div className="text--left">
+            <div className="footer-vercel">
               <a href="https://vercel.com/?utm_source=blitzjs">
                 Hosted on⠀
                 <svg

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.footerLogoLink {
+  opacity: 0.5;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.footerLogoLink:hover {
+  opacity: 1;
+}
+
+.footer-vercel {
+  color: white;
+}


### PR DESCRIPTION
Closes #49

The current Footer content comes from `docusaurus.config.js`. 
Only a few properties are possible in that document, these include: style, links, logo,and copyright. 

I found out about swizzling. It's similar to shadowing in Gatsby.
https://v2.docusaurus.io/docs/using-themes/#swizzling-theme-components

`yarn run swizzle @docusaurus/theme-classic Footer`

Used that to create a custom Footer component, which still takes information from the config file. Then, added the Vercel link in `theme/Footer`.

I had one issue. I wanted to change the default color for links, but could not add custom styles by inserting styles in the generated `styles.module.css`. So I created a `footer_styles.css` file in the Footer folder and imported it.