### PR TITLE
docs(getting-started): fix DB schema

### DIFF
--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -50,7 +50,7 @@ model Task {
   id          Int      @default(autoincrement()) @id
   name        String
   project     Project  @relation(fields: [projectId], references: [id])
-  projectId   Id
+  projectId   Int
 }
 ```
 


### PR DESCRIPTION
Resolves the following error encountered in the Getting Started guide:

```
Type "Id" is neither a built-in type, nor refers to another model, custom type, or enum.
```