### PR TITLE
Temporarily disable dark mode until its styles get fixed

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,12 +14,12 @@ module.exports = {
     },
     announcementBar: {
       id: "progress",
-      content: "🚧Excuse the mess — design in progress! 🚧",
+      content: "🚧Excuse the mess! — A real design is in progress 🚧",
       backgroundColor: "#303846",
       textColor: "#ffffff",
     },
     navbar: {
-      title: "Blitz.js ⚡️",
+      title: "Blitz.js",
       logo: {
         alt: "Blitz.js",
         src: "https://github.com/blitz-js/art/blob/master/square-logo-600.png?raw=true",

--- a/src/components/AnnouncementBar/index.js
+++ b/src/components/AnnouncementBar/index.js
@@ -44,7 +44,7 @@ function AnnouncementBar() {
   return (
     <div
       className={styles.announcementBar}
-      style={{backgroundColor, color: textColor}}
+      style={{backgroundColor: "#6700EB", color: textColor}}
       role="banner">
       <div className={styles.announcementBarContent} dangerouslySetInnerHTML={{__html: content}} />
 

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -236,12 +236,15 @@ function Navbar() {
             .map((linkItem, i) => (
               <NavItem {...linkItem} key={i} />
             ))}
-          <Toggle
-            className={styles.displayOnlyInLargeViewport}
-            aria-label="Dark mode toggle"
-            checked={colorMode === "dark"}
-            onChange={onToggleChange}
-          />
+          {/* TEMPORARILY DISABLE DARK MODE */}
+          {false && (
+            <Toggle
+              className={styles.displayOnlyInLargeViewport}
+              aria-label="Dark mode toggle"
+              checked={colorMode === "dark"}
+              onChange={onToggleChange}
+            />
+          )}
           <SearchBar
             handleSearchBarToggle={setIsSearchBarExpanded}
             isSearchBarExpanded={isSearchBarExpanded}
@@ -257,7 +260,8 @@ function Navbar() {
             )}
             {title != null && <strong className="navbar__title">{title}</strong>}
           </Link>
-          {sidebarShown && (
+          {/* TEMPORARILY DISABLE DARK MODE */}
+          {sidebarShown && false && (
             <Toggle
               aria-label="Dark mode toggle in sidebar"
               checked={colorMode === "dark"}


### PR DESCRIPTION
Disabling dark mode for now so we can go live before everything is converted to theme-ui and dark mode styles fixed.