### PR TITLE
Add documentation for `useParam` hook

### DIFF
--- a/docs/route-params-query.mdx
+++ b/docs/route-params-query.mdx
@@ -8,8 +8,8 @@ sidebar_label: URL Params & Query
 This hook returns all the parameters for the current route as an object. Parameter types are `string` or `string[]`
 
 ```tsx
-// Page: app/products/pages/products/[id].tsx
-// URL: /app/products/pages/products/2
+// File: app/products/pages/products/[id].tsx
+// URL: /products/2
 
 import {useParams} from "blitz"
 
@@ -19,8 +19,8 @@ const params = useParams()
 ```
 
 ```tsx
-// Page: app/pages/blog/[...slug].tsx
-// URL: /app/pages/blog/2020/1
+// File: app/pages/blog/[...slug].tsx
+// URL: /blog/2020/1
 
 const params = useParams()
 
@@ -32,7 +32,7 @@ const params = useParams()
 This hook returns all the query parameters from the URL as an object. Parameter type is always `string`
 
 ```tsx
-// URL:  /products?sort=asc&limit=10
+// URL: /products?sort=asc&limit=10
 
 import {useRouterQuery} from "blitz"
 

--- a/docs/route-params-query.mdx
+++ b/docs/route-params-query.mdx
@@ -27,6 +27,32 @@ const params = useParams()
 // params = {slug: ["2020", "1"]}
 ```
 
+## `useParam`
+
+This hook returns a single parameter cast to chosen type. Available types are: `number`, `string` and `array` which always returns an array of strings.
+
+```tsx
+// File: app/locations/pages/locations/[id]/[[...zipcode]].tsx
+// URL: /locations/2/02137
+
+import {useParam} from "blitz"
+
+const id = useParam("id", "number")
+const zipcodes = useParam("zipcode", "array")
+
+// id = 2
+// zipcodes = ["02137"]
+```
+
+```tsx
+// File: app/pages/blog/[slug].tsx
+// URL: /blog/hello-world
+
+const slug = useParam("slug", "string")
+
+// slug = "hello-world"
+```
+
 ## `useRouterQuery`
 
 This hook returns all the query parameters from the URL as an object. Parameter type is always `string`


### PR DESCRIPTION
This PR adds documentation for `useParam` hook in https://github.com/blitz-js/blitz/pull/637