### PR TITLE
Fixed description of the `router` object's `query `and `params`

### DIFF
--- a/docs/router.mdx
+++ b/docs/router.mdx
@@ -47,7 +47,7 @@ export default withRouter(Page)
 Here's the definition of the `router` object returned by `useRouter` and `withRouter`:
 
 - `pathname`: `String` - Current route. That is the path of the page in `/pages`
-- `query`: `Object` - All the query parameters from the current route. Parameter type is always `string`.
+- `query`: `Object` - All the query string parameters from the current url. Parameter type is always `string`.
 - `params`: `Object` - All the dynamic route parameters for the current route. Parameter types are `string` or `string[]`.
 - `asPath`: `String` - Actual path (including the query) shown in the browser
 - [`push()`](#routerpush): Make page navigation

--- a/docs/router.mdx
+++ b/docs/router.mdx
@@ -47,7 +47,8 @@ export default withRouter(Page)
 Here's the definition of the `router` object returned by `useRouter` and `withRouter`:
 
 - `pathname`: `String` - Current route. That is the path of the page in `/pages`
-- `query`: `Object` - The query string parsed to an object. It will be an empty object during prerendering if the page doesn't have [data fetching requirements](./pages#automatic-static-optimization). Defaults to `{}`
+- `query`: `Object` - All the query parameters from the current route. Parameter type is always `string`.
+- `params`: `Object` - All the parameters for the current route. Parameter types are `string` or `string[]`.
 - `asPath`: `String` - Actual path (including the query) shown in the browser
 - [`push()`](#routerpush): Make page navigation
 - [`replace()`](#routerreplace): Make page navigation without adding to browser history

--- a/docs/router.mdx
+++ b/docs/router.mdx
@@ -48,7 +48,7 @@ Here's the definition of the `router` object returned by `useRouter` and `withRo
 
 - `pathname`: `String` - Current route. That is the path of the page in `/pages`
 - `query`: `Object` - All the query parameters from the current route. Parameter type is always `string`.
-- `params`: `Object` - All the parameters for the current route. Parameter types are `string` or `string[]`.
+- `params`: `Object` - All the dynamic route parameters for the current route. Parameter types are `string` or `string[]`.
 - `asPath`: `String` - Actual path (including the query) shown in the browser
 - [`push()`](#routerpush): Make page navigation
 - [`replace()`](#routerreplace): Make page navigation without adding to browser history


### PR DESCRIPTION
[In this PR](https://github.com/blitz-js/blitz/pull/677), `params` and `query` are added as return values for `useRouter` and `withRouter`.
So, update the documentation of the router object.