### PR TITLE
Update docs to show current generator and console usage

### DIFF
--- a/docs/cli-console.mdx
+++ b/docs/cli-console.mdx
@@ -16,13 +16,17 @@ This makes it very simple to read or write to your database and run one-off comm
 
 You have entered the Blitz console
 Tips: - Exit by typing .exit or pressing Ctrl-D
-      - Use your db like this: db.project.findMany().then(console.log)
-      - Use your queries/mutations like this: getProjects().then(console.log)
-      - Top level `await` support coming: https://github.com/blitz-js/blitz/issues/230
+      - Use your db like this: await db.project.findMany()
+      - Use your queries/mutations like this: await getProjects()
 ✔ Loading your code
 
-⚡ > db.question.findMany().then(console.log)
+⚡ > await db.question.findMany()
 [
-  { id: 1, text: 'What’s up?', publishedAt: 2020-04-24T22:08:17.307Z }
+  {
+    id: 1,
+    createdAt: 2020-06-15T15:06:14.959Z,
+    updatedAt: 2020-06-15T15:06:14.959Z,
+    text: "What's up?"
+  }
 ]
 ```

--- a/docs/cli-generate.mdx
+++ b/docs/cli-generate.mdx
@@ -7,7 +7,7 @@ sidebar_label: blitz generate
 
 Use this command to scaffold all the boring code into your project.
 
-Can generate pages, queries, and mutations. Generating `Prisma` models is coming soon. Also coming soon is support for custom templates based on the built-in templates so you can customize the generator to your app's needs.
+Can generate pages, queries, mutations, and Prisma models. Support for custom templates based on the built-in templates is coming soon, so you can customize the generator to your app's needs.
 
 ```bash
 blitz generate [type] [model]

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -12,7 +12,7 @@ Thanks for trying out Blitz! In this tutorial, we’ll walk you through the crea
 We’ll assume that you have [Blitz installed](./getting-started) already. You can tell if Blitz is installed, and which version you have by running the following command in your terminal:
 
 ```sh
-$ blitz -v
+blitz -v
 ```
 
 If Blitz is installed, you should see the version of your installation. If it isn’t, you’ll get an error saying something like “command not found: blitz”.
@@ -89,12 +89,12 @@ These files are:
 Let’s check that your Blitz project works. Make sure you are in the `mysite` directory, if you haven’t already, and run the following command:
 
 ```sh
-$ blitz start
+blitz start
 ```
 
 You’ll see the following output on the command line:
 
-```sh
+```
 ✔ Prepped for launch
 [ wait ]  starting the development server ...
 [ info ]  waiting on http://localhost:3000 ...
@@ -124,42 +124,82 @@ This is the simplest page possible in Blitz. To look at it, go back to your brow
 
 ## Database setup
 
-Now, we’ll setup the database and create your first model.
+By default, a Blitz app is created with a local SQLite database. If you’re new to databases, or you’re interested in trying Blitz, this is the easiest choice. Note that when starting your first real project, you may want to use a more scalable database like PostgreSQL, to avoid the pains of switching your database down the road. Your data source can be configured in the `db/schema.prisma` file, but for now we can simply move on to the next section.
 
-Open up `db/schema.prisma`. It’s a configuration file which our default database engine Prisma uses.
+## Generating content
 
-By default, the apps is created with SQLite. If you’re new to databases, or you’re interested in trying Blitz, this is the easiest choice. Note that when starting your first project, you may want to use a more scalable database like PostgreSQL, to avoid the pains of switching your database down the road.
+Blitz provides a handy command called [`generate`](./cli-generate) for scaffolding out boilerplate code. We'll use `generate` to create two models: `Question` and `Choice`. A `Question` has the text of the question and a list of choices. A `Choice` has the text of the choice, a vote count, and an associated question. Both models automatically come with an id, a creation timestamp, and a last updated timestamp. In addition to the database layout, passing the `all` type to the `generate` command will also generate the corresponding queries, mutations, and pages for these models!
 
-## Creating models
-
-Now we’ll define your models — essentially your database layout — with additional metadata.
-
-In `schema.prisma`, we’ll create two models: `Question`, and `Choice`. A `Question` has a question and a publication date. A `Choice` has two fields: the text of the choice and a vote count. Each has an id, and each `Choice` is associated with a `Question`.
-
-Edit the `schema.prisma` file so it includes this:
-
-```prisma
-
-model Question {
-  id          Int      @default(autoincrement()) @id
-  text        String
-  publishedAt DateTime
-  choices     Choice[]
-}
-
-model Choice {
-  id         Int      @default(autoincrement()) @id
-  text       String
-  votes      Int      @default(0)
-  question   Question @relation(fields: [questionId], references: [id])
-  questionId Int
-}
-```
-
-Now, we need to migrate our database. This is a way of telling it that you have edited your schema in some way. Run the below command. When it asks you to enter a migration name you can enter anything you want, perhaps "init db":
+First, we'll generate everything pertaining to the `Question` model:
 
 ```sh
-$ blitz db migrate
+blitz generate all question text hasMany:choices
+```
+
+```
+✔ Model for 'question' created successfully:
+
+> model Question {
+>   id        Int      @default(autoincrement()) @id
+>   createdAt DateTime @default(now())
+>   updatedAt DateTime @updatedAt
+>   text      String
+>   choices   Choice[]
+> }
+
+Now run blitz db migrate to add this model to your database
+
+CREATE    app/questions/pages/questions/index.tsx
+CREATE    app/questions/pages/questions/new.tsx
+CREATE    app/questions/pages/questions/[questionId]/edit.tsx
+CREATE    app/questions/pages/questions/[questionId].tsx
+CREATE    app/questions/components/QuestionForm.tsx
+CREATE    app/questions/queries/getQuestions.ts
+CREATE    app/questions/queries/getQuestion.ts
+CREATE    app/questions/mutations/createQuestion.ts
+CREATE    app/questions/mutations/deleteQuestion.ts
+CREATE    app/questions/mutations/updateQuestion.ts
+```
+
+Then, the `Choice` model:
+
+```sh
+blitz generate all choice text votes:int:default[0] belongsTo:question
+```
+
+```
+✔ Model for 'choice' created successfully:
+
+> model Choice {
+>   id         Int      @default(autoincrement()) @id
+>   createdAt  DateTime @default(now())
+>   updatedAt  DateTime @updatedAt
+>   text       String
+>   votes      Int      @default(0)
+>   question   Question @relation(fields: [questionId], references: [id])
+>   questionId Int
+> }
+
+Now run blitz db migrate to add this model to your database
+
+CREATE    app/choices/pages/choices/index.tsx
+CREATE    app/choices/pages/choices/new.tsx
+CREATE    app/choices/pages/choices/[choiceId]/edit.tsx
+CREATE    app/choices/pages/choices/[choiceId].tsx
+CREATE    app/choices/components/ChoiceForm.tsx
+CREATE    app/choices/queries/getChoices.ts
+CREATE    app/choices/queries/getChoice.ts
+CREATE    app/choices/mutations/createChoice.ts
+CREATE    app/choices/mutations/deleteChoice.ts
+CREATE    app/choices/mutations/updateChoice.ts
+```
+
+> Note: you can also edit the `db/schema.prisma` file directly if needed, either instead of using `generate` or afterwards if further modifications are needed.
+
+Now, we need to migrate our database. This is a way of telling it that you have edited your schema in some way. Run the below command. When it asks you to enter a migration name, you can enter anything you want (perhaps "init db"):
+
+```sh
+blitz db migrate
 ```
 
 ## Playing with the API
@@ -167,64 +207,68 @@ $ blitz db migrate
 Now, let’s hop into the interactive Blitz shell and play around with the free API Blitz gives you. To invoke the Blitz console, use this command:
 
 ```sh
-$ blitz console
+blitz console
 ```
 
 Once you’re in the console, explore the Database API:
 
-[//]: # "Let’s move this to await when it’s available for all */"
-
 ```sh
 # No questions are in the system yet.
-⚡ > db.question.findMany().then(console.log)
+⚡ > await db.question.findMany()
 []
 
-# Create a new Question.
-⚡ > let q
+# Create a new Question:
+⚡ > let q = await db.question.create({data: {text: "What's new?"}})
 undefined
 
-⚡ > db.question.create({data: {text: 'What’s new?', publishedAt: new Date()}}).then(res => q = res)
-Promise { <pending> }
-
-# See the entire object
+# See the entire object:
 ⚡ > q
-{ id: 1, text: "What’s new?", publishedAt: 2020-04-24T22:08:17.307Z }
+{
+  id: 1,
+  createdAt: 2020-06-15T15:06:14.959Z,
+  updatedAt: 2020-06-15T15:06:14.959Z,
+  text: "What's new?"
+}
 
-# Or access individual values on the object.
+# Or, access individual values on the object:
 ⚡ > q.text
-"What’s new?"
+"What's new?"
 
-⚡ > q.publishedAt
-2020-04-24T22:08:17.307Z
+⚡ > q.createdAt
+2020-06-15T15:06:14.959Z
 
-# Change values by using the update function
-⚡ > db.question.update({where: {id: 1}, data: {text: 'What’s up?'}}).then(res => q = res)
-Promise { <pending> }
+# Change values by using the update function:
+⚡ > q = await db.question.update({where: {id: 1}, data: {text: "What's up?"}})
+{
+  id: 1,
+  createdAt: 2020-06-15T15:06:14.959Z,
+  updatedAt: 2020-06-15T15:13:17.394Z,
+  text: "What's up?"
+}
 
-# See the result
-⚡ > q
-{ id: 1, text: 'What’s up?', publishedAt: 2020-04-24T22:08:17.307Z }
-
-# db.question.findMany() displays all the questions in the database.
-⚡ > db.question.findMany().then(console.log)
+# db.question.findMany() now displays all the questions in the database:
+⚡ > await db.question.findMany()
 [
-  { id: 1, text: 'What’s up?', publishedAt: 2020-04-24T22:08:17.307Z }
+  {
+    id: 1,
+    createdAt: 2020-06-15T15:06:14.959Z,
+    updatedAt: 2020-06-15T15:13:17.394Z,
+    text: "What's up?"
+  }
 ]
 ```
 
-## Writing more pages
+## Fixing generated pages
 
-Let’s create some more pages. Blitz provides a handy utility for scaffolding out pages, called `generate`. Let’s run it now with our `Question` model:
+[//]: # "Remove this section once `generate` uses actual model attributes"
 
-```sh
-$ blitz generate all question
-```
+> Note: ultimately, this section will not be needed as the generated code will use actual model attributes. Coming soon!
 
-Great! Before running the app again, we need to customise some of these pages which have been generated. Open your text editor and look at `app/questions/pages/questions/index.tsx`. Notice that a `QuestionsList` component has been generated for you:
+Before running the app again, we need to customize some of these pages which have been generated. Open your text editor and look at `app/questions/pages/questions/index.tsx`. Notice that a `QuestionsList` component has been generated for you:
 
 ```jsx
-export const QuestionsList = () => {
-  const [questions] = useQuery(getQuestions, {})
+export const QuestionsList: React.FC = () => {
+  const [questions] = useQuery(getQuestions, {orderBy: {id: "desc"}})
 
   return (
     <ul>
@@ -243,8 +287,8 @@ export const QuestionsList = () => {
 This won’t work though! Remember that the `Question` model we created above doesn’t have any `name` field. To fix this, replace `question.name` with `question.text`:
 
 ```jsx
-export const QuestionsList = () => {
-  const [questions] = useQuery(getQuestions, {})
+export const QuestionsList: React.FC = () => {
+  const [questions] = useQuery(getQuestions, {orderBy: {id: "desc"}})
 
   return (
     <ul>
@@ -269,9 +313,7 @@ const question = await createQuestion({data: {name: "MyName"}})
 with
 
 ```jsx
-const question = await createQuestion({
-  data: {text: "Do you love Blitz?", publishedAt: new Date()},
-})
+const question = await createQuestion({data: {text: "Do you love Blitz?"}})
 ```
 
 Finally, we need to fix the edit page. Open `app/questions/pages/questions/[questionId]/edit.tsx` and replace
@@ -296,9 +338,9 @@ Great! Now make sure your app is running. If it isn’t, run `blitz start` in yo
 
 ## Writing a minimal form
 
-You’re doing great so far! The next thing we’ll do is give our form some real inputs. At the moment it’s giving every `Question` the same name! Have a look at `app/questions/pages/questions/new.tsx` in your editor.
+You’re doing great so far! The next thing we’ll do is give our form some real inputs. At the moment it’s giving every `Question` the same name! Have a look at `app/questions/components/QuestionForm.tsx` in your editor.
 
-Delete the div that says: `<div>Put your form fields here. But for now, click submit</div>`, and replace it with some inputs:
+Delete the div that says: `<div>Put your form fields here. But for now, just click submit</div>`, and replace it with some inputs:
 
 ```jsx
 <input placeholder="Name" />
@@ -308,13 +350,53 @@ Delete the div that says: `<div>Put your form fields here. But for now, click su
 <input placeholder="Choice 1" />
 ```
 
-Finally, we’re going to make sure all that data is submitted. In the end, your page should look something like this:
+Finally, we’re going to make sure all that data is submitted. Open up `app/questions/pages/questions/new.tsx` in your editor and replace
+
+```jsx
+onSubmit={async () => {
+  try {
+    const question = await createQuestion({data: {name: "MyName"}});
+    alert("Success!" + JSON.stringify(question));
+    router.push("/questions/[questionId]", `/questions/${question.id}`);
+  } catch (error) {
+    alert("Error creating question " + JSON.stringify(error, null, 2));
+  }
+}}
+```
+
+with
+
+```jsx
+onSubmit={async (event) => {
+  try {
+    const question = await createQuestion({
+      data: {
+        text: event.target[0].value,
+        choices: {
+          create: [
+            {text: event.target[1].value},
+            {text: event.target[2].value},
+            {text: event.target[3].value},
+          ],
+        },
+      },
+    });
+    alert("Success!" + JSON.stringify(question));
+    router.push("/questions/[questionId]", `/questions/${question.id}`);
+  } catch (error) {
+    alert("Error creating question " + JSON.stringify(error, null, 2));
+  }
+}}
+```
+
+In the end, your page should look something like this:
 
 ```jsx
 import {Head, Link, useRouter} from "blitz"
 import createQuestion from "app/questions/mutations/createQuestion"
+import QuestionForm from "app/questions/components/QuestionForm"
 
-const NewQuestionPage = () => {
+const NewQuestionPage: React.FC = () => {
   const router = useRouter()
 
   return (
@@ -327,15 +409,13 @@ const NewQuestionPage = () => {
       <main>
         <h1>Create New Question </h1>
 
-        <form
+        <QuestionForm
+          initialValues={{}}
           onSubmit={async (event) => {
-            event.preventDefault()
-
             try {
               const question = await createQuestion({
                 data: {
                   text: event.target[0].value,
-                  publishedAt: new Date(),
                   choices: {
                     create: [
                       {text: event.target[1].value},
@@ -351,15 +431,7 @@ const NewQuestionPage = () => {
               alert("Error creating question " + JSON.stringify(error, null, 2))
             }
           }}
-        >
-          <input placeholder="Name" />
-
-          <input placeholder="Choice 1" />
-          <input placeholder="Choice 1" />
-          <input placeholder="Choice 1" />
-
-          <button>Submit</button>
-        </form>
+        />
 
         <p>
           <Link href="/questions">
@@ -376,15 +448,13 @@ export default NewQuestionPage
 
 ## Listing choices
 
-Time for a breather. Go back to `http://localhost:3000/questions` in your browser and look at all the questions you‘ve created. How about we list these questions’ choices here too? First, we need to customise the question queries. In Prisma, you need to manually let the client know that you want to query for nested relations. Change your `getQuestion.ts` and `getQuestions.ts` files to look like this:
+Time for a breather. Go back to `http://localhost:3000/questions` in your browser and look at all the questions you‘ve created. How about we list these questions’ choices here too? First, we need to customize the question queries. In Prisma, you need to manually let the client know that you want to query for nested relations. Change your `getQuestion.ts` and `getQuestions.ts` files to look like this:
 
 ```js
 // app/questions/queries/getQuestion.ts
 
-import db, {FindOneQuestionArgs} from "db"
-
-export default async function getQuestion(args: FindOneQuestionArgs) {
-  const question = await db.question.findOne({...args, include: {choices: true}})
+export default async function getQuestion({where}: GetQuestionInput) {
+  const question = await db.question.findOne({where, include: {choices: true}})
 
   return question
 }
@@ -393,16 +463,27 @@ export default async function getQuestion(args: FindOneQuestionArgs) {
 ```js
 // app/questions/queries/getQuestions.ts
 
-import db, {FindManyQuestionArgs} from "db"
-
-export default async function getQuestions(args: FindManyQuestionArgs) {
-  const questions = await db.question.findMany({...args, include: {choices: true}})
+export default async function getQuestions({
+  where,
+  orderBy,
+  cursor,
+  take,
+  skip,
+}: GetQuestionsInput) {
+  const questions = await db.question.findMany({
+    where,
+    orderBy,
+    cursor,
+    take,
+    skip,
+    include: {choices: true},
+  })
 
   return questions
 }
 ```
 
-Now hop back to our main questions page in your editor, and we can list the choices of each question . Add this code beneath the `Link` in our `QuestionsList`:
+Now hop back to our main questions page in your editor, and we can list the choices of each question. Add this code beneath the `Link` in our `QuestionsList`:
 
 ```jsx
 <ul>
@@ -440,26 +521,7 @@ If you go back to your browser, your page should now look something like this!
   src="https://user-images.githubusercontent.com/24858006/80387990-3c3d8b80-88a1-11ea-956a-5be85f1e8f12.png"
 />
 
-Now that you’ve improved the question page, it’s time for the vote button.
-
-First, we need a new mutation. Create a file at `app/questions/mutations/updateChoice.ts`, and paste in the following code:
-
-```js
-import db, {ChoiceUpdateArgs} from "db"
-
-export default async function updateChoice(args: ChoiceUpdateArgs) {
-  // Don't allow updating ID
-  delete args.data.id
-
-  const choice = await db.choice.update(args)
-
-  return choice
-}
-```
-
-Back in `app/questions/pages/questions/[questionId].tsx`, we can now add a vote button.
-
-In our `li`, add a button like so:
+Now it’s time to add the vote button. In our `li`, add a `button` like so:
 
 ```jsx
 <li key={choice.id}>
@@ -468,18 +530,18 @@ In our `li`, add a button like so:
 </li>
 ```
 
-Then, import our `updateChoice` mutation, and create a `handleVote` function in our page:
+Then, import the `updateChoice` mutation (generated at the beginning) and create a `handleVote` function in our page:
 
 ```jsx
-import updateChoice from "app/questions/mutations/updateChoice"
+import updateChoice from "app/choices/mutations/updateChoice"
 
 ...
 
 const handleVote = async (id, votes) => {
   try {
     const updated = await updateChoice({
-      where: { id },
-      data: { votes: votes + 1 },
+      where: {id},
+      data: {votes: votes + 1},
     })
     alert("Success!" + JSON.stringify(updated))
   } catch (error) {
@@ -492,7 +554,7 @@ return (
 ...
 ```
 
-Finally, we’ll tell our `button` to call that function!
+Finally, we’ll tell our new `button` to call that function!
 
 ```jsx
 <button onClick={() => handleVote(choice.id, choice.votes)}>Vote</button>
@@ -501,22 +563,22 @@ Finally, we’ll tell our `button` to call that function!
 To be sure, this is what all that should look like:
 
 ```jsx
-import { Suspense } from "react"
-import { Head, Link, useRouter, useQuery } from "blitz"
+import React, {Suspense} from "react"
+import {Head, Link, useRouter, useQuery, useParam} from "blitz"
 import getQuestion from "app/questions/queries/getQuestion"
 import deleteQuestion from "app/questions/mutations/deleteQuestion"
-import updateChoice from "app/questions/mutations/updateChoice"
+import updateChoice from "app/choices/mutations/updateChoice"
 
-export const Question = () => {
+export const Question: React.FC = () => {
   const router = useRouter()
-  const questionId = parseInt(router?.query.questionId as string)
-  const [question] = useQuery(getQuestion, { where: { id: questionId } })
+  const questionId = useParam("questionId", "number")
+  const [question] = useQuery(getQuestion, {where: {id: questionId}})
 
   const handleVote = async (id, votes) => {
     try {
       const updated = await updateChoice({
-        where: { id },
-        data: { votes: votes + 1 },
+        where: {id},
+        data: {votes: votes + 1},
       })
       alert("Success!" + JSON.stringify(updated))
     } catch (error) {
@@ -543,19 +605,18 @@ export const Question = () => {
       <button
         type="button"
         onClick={async () => {
-          if (confirm("This will be deleted")) {
-            await deleteQuestion({ where: { id: question.id } })
+          if (window.confirm("This will be deleted")) {
+            await deleteQuestion({where: {id: question.id}})
             router.push("/questions")
           }
-        }}
-      >
+        }}>
         Delete
       </button>
     </div>
   )
 }
 
-const ShowQuestionPage = () => {
+const ShowQuestionPage: React.FC = () => {
   return (
     <div>
       <Head>

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -253,13 +253,49 @@ undefined
 ]
 ```
 
-## Fixing generated pages
+## Fixing generated content
 
-[//]: # "Remove this section once `generate` uses actual model attributes"
+:::info
+Before running the app again, we need to customize some of the content that has been generated. Ultimately, these fixes will not be needed - but for now, we need to work around a couple outstanding issues.
+:::
 
-> Note: ultimately, this section will not be needed as the generated code will use actual model attributes. Coming soon!
+### `deleteQuestion` mutation
 
-Before running the app again, we need to customize some of these pages which have been generated. Open your text editor and look at `app/questions/pages/questions/index.tsx`. Notice that a `QuestionsList` component has been generated for you:
+[//]: # "Remove this section once Prisma supports cascading deletes"
+
+Prisma does not yet support "cascading deletes". In the context of this tutorial, that means it does not currently delete the `Choice` data when deleting a `Question`. We need to temporarily augment the generated `deleteQuestion` mutation in order to do this manually. Open up `app/questions/mutations/deleteQuestion.ts` in your text editor and add the following to the top of the function body:
+
+```js
+// TODO: remove once Prisma supports cascading deletes
+await db.choice.deleteMany({where: {question: {id: where.id}}})
+```
+
+The end result should be as such:
+
+```jsx
+// app/questions/mutations/deleteQuestion.ts
+
+export default async function deleteQuestion(
+  {where}: DeleteQuestionInput,
+  ctx: Record<any, any> = {},
+) {
+  // TODO: remove once Prisma supports cascading deletes
+  await db.choice.deleteMany({where: {question: {id: where.id}}})
+  const question = await db.question.delete({where})
+
+  return question
+}
+```
+
+This mutation will now delete the choices associated with the question prior to deleting the question itself.
+
+### Question pages
+
+[//]: # "Remove the following section once `generate` uses actual model attributes"
+
+The generated page content does not currently use the actual model attributes you defined during generation. It will soon, but in the meantime, let's fix the generated pages.
+
+Jump over to `app/questions/pages/questions/index.tsx`. Notice that a `QuestionsList` component has been generated for you:
 
 ```jsx
 export const QuestionsList = () => {

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -267,7 +267,7 @@ undefined
 Before running the app again, we need to customize some of these pages which have been generated. Open your text editor and look at `app/questions/pages/questions/index.tsx`. Notice that a `QuestionsList` component has been generated for you:
 
 ```jsx
-export const QuestionsList: React.FC = () => {
+export const QuestionsList = () => {
   const [questions] = useQuery(getQuestions, {orderBy: {id: "desc"}})
 
   return (
@@ -287,7 +287,7 @@ export const QuestionsList: React.FC = () => {
 This won’t work though! Remember that the `Question` model we created above doesn’t have any `name` field. To fix this, replace `question.name` with `question.text`:
 
 ```jsx
-export const QuestionsList: React.FC = () => {
+export const QuestionsList = () => {
   const [questions] = useQuery(getQuestions, {orderBy: {id: "desc"}})
 
   return (
@@ -392,11 +392,11 @@ onSubmit={async (event) => {
 In the end, your page should look something like this:
 
 ```jsx
-import {Head, Link, useRouter} from "blitz"
+import {Head, Link, useRouter, BlitzPage} from "blitz"
 import createQuestion from "app/questions/mutations/createQuestion"
 import QuestionForm from "app/questions/components/QuestionForm"
 
-const NewQuestionPage: React.FC = () => {
+const NewQuestionPage: BlitzPage = () => {
   const router = useRouter()
 
   return (
@@ -564,12 +564,12 @@ To be sure, this is what all that should look like:
 
 ```jsx
 import React, {Suspense} from "react"
-import {Head, Link, useRouter, useQuery, useParam} from "blitz"
+import {Head, Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
 import getQuestion from "app/questions/queries/getQuestion"
 import deleteQuestion from "app/questions/mutations/deleteQuestion"
 import updateChoice from "app/choices/mutations/updateChoice"
 
-export const Question: React.FC = () => {
+export const Question = () => {
   const router = useRouter()
   const questionId = useParam("questionId", "number")
   const [question] = useQuery(getQuestion, {where: {id: questionId}})
@@ -609,14 +609,15 @@ export const Question: React.FC = () => {
             await deleteQuestion({where: {id: question.id}})
             router.push("/questions")
           }
-        }}>
+        }}
+      >
         Delete
       </button>
     </div>
   )
 }
 
-const ShowQuestionPage: React.FC = () => {
+const ShowQuestionPage: BlitzPage = () => {
   return (
     <div>
       <Head>

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -128,7 +128,7 @@ By default, a Blitz app is created with a local SQLite database. If you’re new
 
 ## Generating content
 
-Blitz provides a handy command called [`generate`](./cli-generate) for scaffolding out boilerplate code. We'll use `generate` to create two models: `Question` and `Choice`. A `Question` has the text of the question and a list of choices. A `Choice` has the text of the choice, a vote count, and an associated question. Both models automatically come with an id, a creation timestamp, and a last updated timestamp. In addition to the database layout, passing the `all` type to the `generate` command will also generate the corresponding queries, mutations, and pages for these models!
+Blitz provides a handy command called [`generate`](./cli-generate) for scaffolding out boilerplate code. We'll use `generate` to create two models: `Question` and `Choice`. A `Question` has the text of the question and a list of choices. A `Choice` has the text of the choice, a vote count, and an associated question. Both models automatically come with an id, a creation timestamp, and a last updated timestamp.
 
 First, we'll generate everything pertaining to the `Question` model:
 
@@ -161,10 +161,10 @@ CREATE    app/questions/mutations/deleteQuestion.ts
 CREATE    app/questions/mutations/updateQuestion.ts
 ```
 
-Then, the `Choice` model:
+Then, we'll generate the `Choice` model with corresponding queries and mutations. We'll pass a type of `resource` this time as we don't need to generate pages for the `Choice` model:
 
 ```sh
-blitz generate all choice text votes:int:default[0] belongsTo:question
+blitz generate resource choice text votes:int:default[0] belongsTo:question
 ```
 
 ```
@@ -182,11 +182,6 @@ blitz generate all choice text votes:int:default[0] belongsTo:question
 
 Now run blitz db migrate to add this model to your database
 
-CREATE    app/choices/pages/choices/index.tsx
-CREATE    app/choices/pages/choices/new.tsx
-CREATE    app/choices/pages/choices/[choiceId]/edit.tsx
-CREATE    app/choices/pages/choices/[choiceId].tsx
-CREATE    app/choices/components/ChoiceForm.tsx
 CREATE    app/choices/queries/getChoices.ts
 CREATE    app/choices/queries/getChoice.ts
 CREATE    app/choices/mutations/createChoice.ts

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -453,7 +453,10 @@ Time for a breather. Go back to `http://localhost:3000/questions` in your browse
 ```js
 // app/questions/queries/getQuestion.ts
 
-export default async function getQuestion({where}: GetQuestionInput) {
+export default async function getQuestion(
+  {where /* include */}: GetQuestionInput,
+  ctx: Record<any, any> = {},
+) {
   const question = await db.question.findOne({where, include: {choices: true}})
 
   return question
@@ -463,13 +466,10 @@ export default async function getQuestion({where}: GetQuestionInput) {
 ```js
 // app/questions/queries/getQuestions.ts
 
-export default async function getQuestions({
-  where,
-  orderBy,
-  cursor,
-  take,
-  skip,
-}: GetQuestionsInput) {
+export default async function getQuestions(
+  {where, orderBy, cursor, take, skip}: GetQuestionsInput,
+  ctx: Record<any, any> = {},
+) {
   const questions = await db.question.findMany({
     where,
     orderBy,


### PR DESCRIPTION
We'll want to wait for the next Blitz release before merging this (depends on https://github.com/blitz-js/blitz/pull/659), but it should be ready to review at least.

I started out with the goal of updating the REPL examples to use top-level await, but ran into overall flow issues with the tutorial now that model generation is in (specifically, manually creating the model definitions in `db/schema.prisma` followed by `blitz generate all` yields undesired results). Per feedback in Slack from Brandon and Adam, I made some fairly significant updates to the tutorial to reflect the current recommended way of doing things (as I perceive them, anyway). As a result, this turned into a bigger update than I had originally intended, but I think it results in a better user experience.
