### PR TITLE
Added social preview images

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,7 @@ module.exports = {
       apiKey: "c4db860ae4162be48d4c867e33edcaa2",
       indexName: "blitzjs",
     },
+    image: "img/logo-bg-purple.png",
     announcementBar: {
       id: "progress",
       content:

--- a/src/components/DocPage/index.js
+++ b/src/components/DocPage/index.js
@@ -36,7 +36,10 @@ function DocPage(props) {
   }
 
   return (
-    <Layout version={version}>
+    <Layout
+      version={version}
+      description="Built on Next.js. Inspired by Ruby on Rails. New Fullstack Data Layer. Fullstack has never been this easy!"
+    >
       <div className={styles.docPage}>
         {sidebar && (
           <div className={styles.docSidebarContainer}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -105,7 +105,7 @@ function Home() {
   return (
     <Layout
       title="Blitz.js - The Fullstack React Framework"
-      description="Description will go into a meta tag in <head />"
+      description="Built on Next.js. Inspired by Ruby on Rails. New Fullstack Data Layer. Fullstack has never been this easy!"
     >
       <Grid sx={{px: [3, 5]}}>
         <Spaced


### PR DESCRIPTION
This PR closes the issue of Added social preview images. #79 
![スクリーンショット 2020-06-22 2 34 13](https://user-images.githubusercontent.com/32378535/85231333-211a7280-b431-11ea-9add-be4f9bd00d78.png)
