### PR TITLE
Correct typo in exotic, suggest change to unusual

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -58,4 +58,4 @@ How you can help:
 1. Report bugs by [opening an issue on GitHub](https://github.com/blitz-js/blitz/issues/new/choose)
 1. Contribute code: [Read the contributing guide so see how to get started](./contributing).
 1. [Sponsorships & donations](https://github.com/blitz-js/blitz#sponsors-and-donations)
-1. Any other way you want! We totally appreciate any type of contribution, such as documentation, videos, blog posts, etc. If you have an excotic idea, feel free to run it past us in Slack! :)
+1. Any other way you want! We totally appreciate any type of contribution, such as documentation, videos, blog posts, etc. If you have an unusual idea, feel free to run it past us in Slack! :)


### PR DESCRIPTION
Noticed exotic was typod, but while correcting wondered if 'exotic' is the best choice of word here. It's often used by westerners to mean `foreign to westerners`. Perhaps unusual is a more inclusive choice.