### PR TITLE
Add Optimistic Updates section and details for refetch option in useQuery mutate()

### DIFF
--- a/docs/mutation-usage.mdx
+++ b/docs/mutation-usage.mdx
@@ -89,3 +89,60 @@ export default function (props) {
 #### Automatically
 
 We want to somehow automatically invalidate your query cache. We're not sure how to do this yet, but we have [an open issue that you're welcome to contribute to!](https://github.com/blitz-js/blitz/issues/586)
+
+## Optimistic Updates
+
+Optimistic UI patterns are a technique for making your apps feel more responsive to user interactions. When a user takes an action (for example liking a post) we can avoid showing activity spinners or loading animations by simply assuming the action was successful. We update our local cache and interface immediately to show a successful result.
+
+When the real response arrives from the action we then update the UI to reflect the true value returned from the database. In most cases, with a successful request, this will be invisible to the user, and the change will appear to have occurred instantly.
+
+In the case of an error, we revert the local change, refetch the data, and optionally show an error message.
+
+Here's a simple form component with an `onSubmit` function that calls an `updateProduct` mutation to save edits.
+
+```tsx
+export default function (props: {query: {id: number}}) {
+  const [product, {mutate}] = useQuery(getProduct, {where: {id: props.query.id}})
+  return (
+    <Formik
+      initialValues={product}
+      onSubmit={async (values) => {
+        try {
+          const product = await updateProduct(values)
+          mutate(product)
+        } catch (error) {
+          alert("Error saving product")
+        }
+      }}>
+      {/* ... */}
+    </Formik>
+  )
+}
+```
+
+We can enhance this to support instant feedback to the user, immediately showing the edited product information, by mutating the local cache of the `getProducts` query with the changes we're about to send to the database.
+
+```tsx
+export default function (props: {query: {id: number}}) {
+  const [product, {mutate}] = useQuery(getProduct, {where: {id: props.query.id}})
+  return (
+    <Formik
+      initialValues={product}
+      onSubmit={async (values) => {
+        try {
+          // Update local cache with form values without triggering refetch
+          mutate(values, {refetch: false}) // highlight-line
+          const product = await updateProduct(values)
+          // Update local cache with result, then refetch
+          mutate(product)
+        } catch (error) {
+          // Set cache back to original result, then refetch
+          mutate(product) // highlight-line
+          alert("Error saving product")
+        }
+      }}>
+      {/* ... */}
+    </Formik>
+  )
+}
+```

--- a/docs/mutation-usage.mdx
+++ b/docs/mutation-usage.mdx
@@ -38,7 +38,7 @@ Any errors thrown from your server code will be thrown on the client exactly lik
 #### `mutate`
 
 - [`useQuery`](./use-query.mdx) returns a `mutate` function you can use to manually update the cache
-- Calling `mutate` will automatically trigger a refetch for the initial query to ensure it has the correct data
+- Calling `mutate` will automatically trigger a refetch for the initial query to ensure it has the correct data. Disable refetch by passing an options object `{refetch: false}` as the second argument.
 
 ```tsx
 export default function (props: {query: {id: number}}) {

--- a/docs/mutation-usage.mdx
+++ b/docs/mutation-usage.mdx
@@ -121,6 +121,7 @@ export default function (props: {query: {id: number}}) {
 ```
 
 We can enhance this to support instant feedback to the user, immediately showing the edited product information, by mutating the local cache of the `getProducts` query with the changes we're about to send to the database.
+We pass `{refetch: false}` as a second argument to the mutate() function to prevent the mutation triggering a refetch of stale data while we wait for the response.
 
 ```tsx
 export default function (props: {query: {id: number}}) {

--- a/docs/use-infinite-query.mdx
+++ b/docs/use-infinite-query.mdx
@@ -198,9 +198,9 @@ const [
   - `pageOptionsOverride` allows you to optionally override the result returned from your `getCanFetchMore` function
 - `canFetchMore: Boolean`
   - If using `paginated` mode, this will be `true` if there is more data to be fetched (known via the required `getFetchMore` option function).
-- `mutate()` - `Function(newData) => void`
+- `mutate()` - `Function(newData, opts) => void`
   - A function to manually update the cache for a query.
   - `newData` can be an object of new data or a function that receives the old data and returns the new data
   - This is often used to instantly update the cache after submitting a form
-  - After updating the cache, this will automatically call `refetch()` to ensure the data is correct
+  - After updating the cache, this will automatically call `refetch()` to ensure the data is correct. Disable refetch by passing an options object `{refetch: false}` as the second argument.
   - See the [Blitz mutation usage docs](./mutation-usage#mutate) for example usage of `mutate()`

--- a/docs/use-query.mdx
+++ b/docs/use-query.mdx
@@ -152,9 +152,9 @@ const [
   - A function to manually refetch the query if it is stale.
   - To bypass the stale check, you can pass the `force: true` option and refetch it regardless of it's freshness
   - If the query errors, the error will only be logged. If you want an error to be thrown, pass the `throwOnError: true` option
-- `mutate()` - `Function(newData) => void`
+- `mutate()` - `Function(newData, opts) => void`
   - A function to manually update the cache for a query.
   - `newData` can be an object of new data or a function that receives the old data and returns the new data
   - This is often used to instantly update the cache after submitting a form
-  - After updating the cache, this will automatically call `refetch()` to ensure the data is correct
+  - After updating the cache, this will automatically call `refetch()` to ensure the data is correct. Disable refetch by passing an options object `{refetch: false}` as the second argument.
   - See the [Blitz mutation usage docs](./mutation-usage#mutate) for example usage of `mutate()`


### PR DESCRIPTION
Add a simple sentence explaining the option to disable refetch when calling mutate. https://github.com/blitz-js/blitz/pull/715

Added in all locations it was relevant, but if it's too much detail for the useQuery/useInfiniteQuery pages I can remove those and leave it only on the Mutation Usage details. Thoughts?