### PR TITLE
Enable highlighting specific lines within code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When tagging a new version, the document versioning mechanism will:
 
 [See the Docusaurus documention on versioning](https://v2.docusaurus.io/docs/versioning/#tagging-a-new-version)
 
-## Comment Highlights
+## Code Syntax Highlights
 
 Code blocks are syntax highlighted using Prism. You can call attention to specific sections in a code block using comments to begin and end a block `// highlight-start` `// highlight-end`, or highlight a single line `// highlight-line`
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ When tagging a new version, the document versioning mechanism will:
 3. Append the new version number into versions.json.
 
 [See the Docusaurus documention on versioning](https://v2.docusaurus.io/docs/versioning/#tagging-a-new-version)
+
+## Comment Highlights
+
+Code blocks are syntax highlighted using Prism. You can call attention to specific sections in a code block using comments to begin and end a block `// highlight-start` `// highlight-end`, or highlight a single line `// highlight-line`
+
+```
+const example = "not highlighted"
+// highlight-start
+const highlighted = true
+// highlight-end
+const notHighlighted = true
+const alsoHighlighted = true // highlight-line
+```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.55",
     "@docusaurus/plugin-google-gtag": "^2.0.0-alpha.55",
     "@docusaurus/plugin-sitemap": "^2.0.0-alpha.55",
-    "@theme-ui/prism": "0.3.0",
+    "@theme-ui/prism": "v0.4.0-rc.1",
     "algoliasearch": "^3.24.5",
     "algoliasearch-helper": "^3.1.1",
     "classnames": "^2.2.6",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,3 +53,11 @@ a:hover {
   color: inherit;
   text-decoration: inherit;
 }
+
+.highlight {
+  background: #cad9e7;
+  border-left: 4px solid var(--ifm-menu-color-active);
+  padding-left: 12px;
+  margin-left: -16px;
+  margin-right: -16px;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -72,3 +72,12 @@ pre.prism-code .token-line:before {
   opacity: 0.3;
   margin-right: 8px;
 }
+
+/* Disable line numbers for some languages */
+pre.prism-code.language-sh .token-line:before,
+pre.prism-code.language-bash .token-line:before,
+pre.prism-code.language-css-cgycug .token-line:before {
+  opacity: 1;
+  margin-right: 0;
+  content: "";
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -54,10 +54,21 @@ a:hover {
   text-decoration: inherit;
 }
 
-.highlight {
-  background: #cad9e7;
+pre.prism-code .highlight {
+  background: #dce8f2;
   border-left: 4px solid var(--ifm-menu-color-active);
   padding-left: 12px;
   margin-left: -16px;
   margin-right: -16px;
+}
+
+pre.prism-code {
+  counter-reset: line;
+}
+
+pre.prism-code .token-line:before {
+  counter-increment: line;
+  content: counter(line);
+  opacity: 0.3;
+  margin-right: 8px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -55,7 +55,7 @@ a:hover {
 }
 
 pre.prism-code .highlight {
-  background: #dce8f2;
+  background: #e1e6f8;
   border-left: 4px solid var(--ifm-menu-color-active);
   padding-left: 12px;
   margin-left: -16px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -70,7 +70,7 @@ pre.prism-code .token-line:before {
   counter-increment: line;
   content: counter(line);
   opacity: 0.3;
-  margin-right: 8px;
+  margin-right: 12px;
 }
 
 /* Disable line numbers for some languages */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,10 +1720,10 @@
     "@emotion/styled" "^10.0.0"
     "@mdx-js/react" "^1.0.0"
 
-"@theme-ui/prism@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@theme-ui/prism/-/prism-0.3.0.tgz#69c2f8bf5f5c5d02f1bde5879a149f6cadab2b7c"
-  integrity sha512-5M3uH5zShttu5k84OfCIWrFKFTrPdck/m/1iU/9i8CMM899mIu7VsVTgaUTKkOCMoreH2u+d7Y76j4Ur2ZMzEw==
+"@theme-ui/prism@v0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@theme-ui/prism/-/prism-0.4.0-rc.1.tgz#79913008cf4272e4fbc226bb0f025957198e5257"
+  integrity sha512-FiUM2YlHmf60xFmY6Y72el76q/ayy3FWyaEnfki5uW7a/lMGf0Ev1gOc2yUpGpzh3XxNbk2R0XdReQuqDcKm5Q==
   dependencies:
     prism-react-renderer "^1.0.2"
 


### PR DESCRIPTION
Closes: #98 

Upgraded to @theme-ui/prism 4.0-rc.1 for support for commented code highlighting like so:

```
const example = "not highlighted";
// highlight-start
const highlighted = true;
// highlight-end
const alsoHighlighted = true // highlight-line
```

Adds a custom CSS class to visually distinguish the highlighted lines.