### PR TITLE
Update default question to include choice

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -344,7 +344,9 @@ const question = await createQuestion({data: {name: "MyName"}})
 with
 
 ```jsx
-const question = await createQuestion({data: {text: "Do you love Blitz?"}})
+const question = await createQuestion({
+  data: {text: "Do you love Blitz?", choices: {create: [{text: "Yes!"}]}},
+})
 ```
 
 Finally, we need to fix the edit page. Open `app/questions/pages/questions/[questionId]/edit.tsx` and replace


### PR DESCRIPTION
In the tutorial you update `new.tsx` to create a default question "Do you love Blitz?".  Then later make updates for "Listing Choices" in the `QuestionsList` component and `[questionsId].tsx`.  After we are given an example of what the page should look like, but no where do we add choices for this default question, which might create confusion if the choices code is working/etc.  

Adding the "Yes!" choice while creating the default question will make the result after listing choices match the tutorials outcome. 