### PR TITLE
Adding a "What is Next.js?" section

### DIFF
--- a/docs/what-is-nextjs.mdx
+++ b/docs/what-is-nextjs.mdx
@@ -1,6 +1,6 @@
 # What is Next.js?
 
-\*\*\*\*[**Next.js**](https://nextjs.org/) ****is a popular React Framework with many built-in features, such as:
+[**Next.js**](https://nextjs.org/) is a popular React Framework with many built-in features, such as:
 
 * An intuitive page-based routing system \(with support for dynamic routes\)
 * Pre-rendering, both static generation \(SSG\) and server-rendering \(SSR\) are supported on a per-page basis

--- a/docs/what-is-nextjs.mdx
+++ b/docs/what-is-nextjs.mdx
@@ -3,19 +3,12 @@ title: What is Next.js?
 sidebar_label: What is Next.js?
 ---
 
-# What is Next.js?
+Next.js is baked into Blitz and almost all features of Next.js are supported. For more info on the differences see here: [Why use Blitz instead of Next.js](https://blitzjs.com/docs/why-blitz)
 
 [**Next.js**](https://nextjs.org/) is a popular React Framework with many built-in features, such as:
 
-* An intuitive page-based routing system \(with support for dynamic routes\)
 * Pre-rendering, both static generation \(SSG\) and server-rendering \(SSR\) are supported on a per-page basis
 * Automatic code splitting for faster page loads
 * Client-side routing with optimized prefetching
-* Built-in CSS and Sass support, and support for any CSS-in-JS library
 * Development environment which supports Hot Module Replacement
-* API routes to build API endpoints with Serverless Functions
 * Fully extendable
-
-## FYI
-
-Next.js is baked into blitz and almost all features of Next.js are supported. For more info on the differences see here: [Why use Blitz instead of Next.js](https://blitzjs.com/docs/why-blitz)

--- a/docs/what-is-nextjs.mdx
+++ b/docs/what-is-nextjs.mdx
@@ -1,0 +1,16 @@
+# What is Next.js?
+
+\*\*\*\*[**Next.js**](https://nextjs.org/) ****is a popular React Framework with many built-in features, such as:
+
+* An intuitive page-based routing system \(with support for dynamic routes\)
+* Pre-rendering, both static generation \(SSG\) and server-rendering \(SSR\) are supported on a per-page basis
+* Automatic code splitting for faster page loads
+* Client-side routing with optimized prefetching
+* Built-in CSS and Sass support, and support for any CSS-in-JS library
+* Development environment which supports Hot Module Replacement
+* API routes to build API endpoints with Serverless Functions
+* Fully extendable
+
+## FYI
+
+Next.js is baked into blitz and almost all features of Next.js are supported. For more info on the differences see here: [Why use Blitz instead of Next.js](https://blitzjs.com/docs/why-blitz)

--- a/docs/what-is-nextjs.mdx
+++ b/docs/what-is-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
-title: What is Next.js
-sidebar_label: What is Next.js
+title: What is Next.js?
+sidebar_label: What is Next.js?
 ---
 
 # What is Next.js?

--- a/docs/what-is-nextjs.mdx
+++ b/docs/what-is-nextjs.mdx
@@ -1,3 +1,8 @@
+---
+title: What is Next.js
+sidebar_label: What is Next.js
+---
+
 # What is Next.js?
 
 [**Next.js**](https://nextjs.org/) is a popular React Framework with many built-in features, such as:

--- a/docs/why-blitz.mdx
+++ b/docs/why-blitz.mdx
@@ -1,5 +1,5 @@
 ---
-title: Why would someone use Blitz instead of Next.js?
+title: Why use Blitz instead of Next.js?
 sidebar_label: Why Blitz instead of Next.js?
 ---
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,6 +12,7 @@ module.exports = {
       "tutorial",
       "manifesto",
       "why-blitz",
+      "what-is-nextjs",
       "code-of-conduct",
       "contributing",
     ],


### PR DESCRIPTION
This is based off of a conversation in slack that can be found here: https://blitzjs.slack.com/archives/CUA5KK1BR/p1593475057295400

What I'm trying to do here is provide a little context if a person is reading the docs and thinks "what is Next.js?". I feel this is enough info to get the gist and worse case scenario they can learn more at their site.

I adapted this from this doc [here](https://docs.magic.link/technologies/next-js-integration) and removed some info I felt like would only add confusion.

Also, I renamed the `Why would someone use Blitz instead of Next.js?` to `Why use Blitz instead of Next.js?` just to make it more readable.