### PR TITLE
Update document for react-query v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,13 @@ name: Continuous Integration
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the main branch
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/docs/query-usage.mdx
+++ b/docs/query-usage.mdx
@@ -46,11 +46,12 @@ See [the `useQuery` documentation](./use-query) for a full list of possible opti
 
 ### Dependent Queries
 
-The second query will not execute until the second function argument can be called without throwing.
+Dependent queries are queries that depend on previous ones to finish before they can execute.
+To do this, use the enabled option to tell a query when it is ready to turn on:
 
 ```tsx
 const [user] = useQuery(getUser, {where: {id: props.query.id}})
-const [projects] = useQuery(getProjects, () => ({where: {userId: user.id}}))
+const [projects] = useQuery(getProjects, () => ({where: {userId: user.id}}, {enabled: user}))
 ```
 
 ### Pagination

--- a/docs/use-infinite-query.mdx
+++ b/docs/use-infinite-query.mdx
@@ -29,7 +29,7 @@ function Products(props) {
       ))}
 
       <div>
-        <button onClick={() => fetchMore()} disabled={!canFetchMore || isFetchingMore}>
+        <button onClick={() => fetchMore()} disabled={!canFetchMore || !!isFetchingMore}>
           {isFetchingMore ? "Loading more..." : canFetchMore ? "Load More" : "Nothing more to load"}
         </button>
       </div>
@@ -80,6 +80,7 @@ const [
   // options
   getFetchMore: (lastPage, allPages) => pageOptions
   manual,
+  enabled,
   retry,
   retryDelay,
   staleTime
@@ -115,10 +116,14 @@ const [
 - `manual: Boolean`
   - Set this to `true` to disable automatic refetching when the query mounts or changes query keys.
   - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
+- `enabled: Boolean`
+  - Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
+  - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
 - `retry: Boolean | Int | Function(failureCount, error) => shouldRetry | Boolean`
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
   - If set to an `Int`, e.g. `3`, failed queries will retry until the failed query count meets that number.
+  - If set to a function `(failureCount, error) => boolean` failed queries will retry until the function returns false.
 - `retryDelay: Function(retryAttempt: Int) => Int`
   - This function receives a `retryAttempt` integer and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.
@@ -181,9 +186,10 @@ const [
   - A function to manually refetch the query if it is stale.
   - To bypass the stale check, you can pass the `force: true` option and refetch it regardless of it's freshness
   - If the query errors, the error will only be logged. If you want an error to be thrown, pass the `throwOnError: true` option
-- `fetchMore()` - `Function(pageOptionsOverride) => Promise`
+- `fetchMore()` - `Function(fetchMoreVariableOverride, { previous }) => Promise`
   - This function allows you to fetch the next "page" of results.
-  - `pageOptionsOverride` allows you to optionally override the result returned from your `getCanFetchMore` function
+  - fetchMoreVariableOverride allows you to optionally override the fetch more variable returned from your getCanFetchMore option to your query function to retrieve the next page of results.
+  - previous option which will determine if the data you are fetching is should be prepended instead of appended to your infinite list. e.g. `fetchMore(nextPageVars, { previous: true })`
 - `canFetchMore: Boolean`
   - If using `paginated` mode, this will be `true` if there is more data to be fetched (known via the required `getFetchMore` option function).
 - `mutate()` - `Function(newData) => void`

--- a/docs/use-paginated-query.mdx
+++ b/docs/use-paginated-query.mdx
@@ -65,6 +65,7 @@ const [
   }
 ] = useQuery(blitzQueryFunction, queryInputArguments, {
   manual,
+  enabled,
   retry,
   retryDelay,
   staleTime,
@@ -96,10 +97,14 @@ const [
 - `manual: Boolean`
   - Set this to `true` to disable automatic refetching when the query mounts or changes query keys.
   - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
+- `enabled: Boolean`
+  - Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
+  - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
 - `retry: Boolean | Int | Function(failureCount, error) => shouldRetry | Boolean`
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
   - If set to an `Int`, e.g. `3`, failed queries will retry until the failed query count meets that number.
+  - If set to a function `(failureCount, error) => boolean` failed queries will retry until the function returns false.
 - `retryDelay: Function(retryAttempt: Int) => Int`
   - This function receives a `retryAttempt` integer and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.

--- a/docs/use-query.mdx
+++ b/docs/use-query.mdx
@@ -54,6 +54,7 @@ const [
   }
 ] = useQuery(blitzQueryFunction, queryInputArguments, {
   manual,
+  enabled,
   retry,
   retryDelay,
   staleTime,
@@ -85,10 +86,14 @@ const [
 - `manual: Boolean`
   - Set this to `true` to disable automatic refetching when the query mounts or input arguments change.
   - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
+- `enabled: Boolean`
+  - Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
+  - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
 - `retry: Boolean | Int | Function(failureCount, error) => shouldRetry | Boolean`
   - If `false`, failed queries will not retry by default.
   - If `true`, failed queries will retry infinitely.
   - If set to an `Int`, e.g. `3`, failed queries will retry until the failed query count meets that number.
+  - If set to a function `(failureCount, error) => boolean` failed queries will retry until the function returns false.
 - `retryDelay: Function(retryAttempt: Int) => Int`
   - This function receives a `retryAttempt` integer and returns the delay to apply before the next attempt in milliseconds.
   - A function like `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)` applies exponential backoff.


### PR DESCRIPTION
Updated documentation for the update to react-query v2.
Implementation is [here](https://github.com/blitz-js/blitz/pull/720).