### PR TITLE
Added syntax highlighting to tutorial

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -279,8 +279,10 @@ export default async function deleteQuestion(
   {where}: DeleteQuestionInput,
   ctx: Record<any, any> = {},
 ) {
+  // highlight-start
   // TODO: remove once Prisma supports cascading deletes
   await db.choice.deleteMany({where: {question: {id: where.id}}})
+  // highlight-end
   const question = await db.question.delete({where})
 
   return question
@@ -306,7 +308,7 @@ export const QuestionsList = () => {
       {questions.map((question) => (
         <li key={question.id}>
           <Link href="/questions/[questionId]" as={`/questions/${question.id}`}>
-            <a>{question.name}</a>
+            <a>{question.name}</a> // highlight-line
           </Link>
         </li>
       ))}
@@ -326,7 +328,7 @@ export const QuestionsList = () => {
       {questions.map((question) => (
         <li key={question.id}>
           <Link href="/questions/[questionId]" as={`/questions/${question.id}`}>
-            <a>{question.text}</a>
+            <a>{question.text}</a> // highlight-line
           </Link>
         </li>
       ))}
@@ -444,6 +446,7 @@ const NewQuestionPage: BlitzPage = () => {
 
         <QuestionForm
           initialValues={{}}
+          // highlight-start
           onSubmit={async (event) => {
             try {
               const question = await createQuestion({
@@ -464,6 +467,7 @@ const NewQuestionPage: BlitzPage = () => {
               alert("Error creating question " + JSON.stringify(error, null, 2))
             }
           }}
+          // highlight-end
         />
 
         <p>
@@ -600,13 +604,14 @@ import React, {Suspense} from "react"
 import {Head, Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
 import getQuestion from "app/questions/queries/getQuestion"
 import deleteQuestion from "app/questions/mutations/deleteQuestion"
-import updateChoice from "app/choices/mutations/updateChoice"
+import updateChoice from "app/choices/mutations/updateChoice" // highlight-line
 
 export const Question = () => {
   const router = useRouter()
   const questionId = useParam("questionId", "number")
   const [question] = useQuery(getQuestion, {where: {id: questionId}})
 
+  // highlight-start
   const handleVote = async (id, votes) => {
     try {
       const updated = await updateChoice({
@@ -630,11 +635,10 @@ export const Question = () => {
           </li>
         ))}
       </ul>
-
+      // highlight-end
       <Link href="/questions/[questionId]/edit" as={`/questions/${question.id}/edit`}>
         <a>Edit</a>
       </Link>
-
       <button
         type="button"
         onClick={async () => {
@@ -657,7 +661,6 @@ const ShowQuestionPage: BlitzPage = () => {
         <title>Question</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-
       <main>
         <p>
           <Link href="/questions">


### PR DESCRIPTION
This closes #103 

I've added syntax highlighting to the tutorial page but I ran into some small issue or maybe I overlooked something.
In the last part, I wanted to highlight the code blocks separately instead of highlighting it all as I did now. I don't know if that makes a huge difference for the user but I stumbled upon some weird behavior as you can see in the screenshots below. When I've already selected a piece of code, `handleVote()`, and I want to select the questions list it doesn't highlight the right code. It's off by two lines. When I remove the highlight at `handleVote()` it does work.

I've tried to 'cheat' to two-line offset in the second part but I wasn't able to grab the piece of code so I ended up highlighting the whole thing instead. 

![highlight-code](https://user-images.githubusercontent.com/7902980/88033836-222de500-cb40-11ea-9959-7d6dc9040518.JPG)

![highlight-doc](https://user-images.githubusercontent.com/7902980/88032957-01b15b00-cb3f-11ea-8e67-d88c48b6066b.JPG)

