### PR TITLE
Set NODE_ENV to production when migrating

### DIFF
--- a/docs/deploy-vercel.mdx
+++ b/docs/deploy-vercel.mdx
@@ -25,6 +25,6 @@ Assuming you already have a [Vercel](https://vercel.com) account:
 3. You need your entire database connection string. If you need, [read the Prisma docs on this](https://www.prisma.io/docs/reference/database-connectors/postgresql#connection-details).
    1. Make sure you get the connection string to your connection pool, not directly to the DB.
    2. If using pgBouncer (default connection pool on Digital Ocean), you must add `?pgbouncer=true` to the end of your connection string for Prisma to work correctly.
-4. Change your build script in package.json to be `blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
+4. Change your build script in package.json to be `NODE_ENV=production blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
 5. Add your DB url as a secret environment variable [using the UI](https://vercel.com/blog/environment-variables-ui) or by running `vercel env add DATABASE_URL`
 6. Run `git push` if using the [Git Integration](https://vercel.com/docs/v2/git-integrations) or `vercel` if using Vercel CLI


### PR DESCRIPTION
I noticed that when trying to deploy to Vercel it was hanging at the migration step. It looks like this issue was resolved in blitz-js/blitz#786, but depends on `NODE_ENV` being set to production for the build step. I've updated the docs to reflect the change required for the migrations to proceed.