### PR TITLE
usePaginatedQuery docs example incorrect #129

### DIFF
--- a/docs/use-infinite-query.mdx
+++ b/docs/use-infinite-query.mdx
@@ -7,33 +7,30 @@ sidebar_label: useInfiniteQuery
 
 ```ts
 import {useInfiniteQuery} from "blitz"
-import getProducts from "/app/products/queries/getProducts"
+import getProjectsInfinite from "app/projects/queries/getProjectsInfinite"
 
-function Products(props) {
-  const [groupedProducts, {isFetching, isFetchingMore, fetchMore, canFetchMore}] = useInfiniteQuery(
-    getProducts,
-    (page = {take: 100, skip: 0}) => ({where: {storeId: props.storeId}, ...page}),
+function Projects(props) {
+  const [groupedProjects, {isFetching, isFetchingMore, fetchMore, canFetchMore}] = useInfiniteQuery(
+    getProjectsInfinite,
+    (page = {take: 3, skip: 0}) => page,
     {
-      getFetchMore: (lastGroup, allGroups) => lastGroup.nextPage,
+      getFetchMore: (lastGroup) => lastGroup.nextPage,
     },
   )
-
   return (
     <>
-      {groupedProducts.map((group, i) => (
+      {groupedProjects.map((group, i) => (
         <React.Fragment key={i}>
-          {group.products.map((product) => (
-            <p key={product.id}>{product.name}</p>
+          {group.projects.map((project) => (
+            <p key={project.id}>{project.name}</p>
           ))}
         </React.Fragment>
       ))}
-
       <div>
         <button onClick={() => fetchMore()} disabled={!canFetchMore || !!isFetchingMore}>
           {isFetchingMore ? "Loading more..." : canFetchMore ? "Load More" : "Nothing more to load"}
         </button>
       </div>
-
       <div>{isFetching && !isFetchingMore ? "Fetching..." : null}</div>
     </>
   )
@@ -43,20 +40,25 @@ function Products(props) {
 And here's the query to work with that:
 
 ```ts
-export default async function getProducts({where, orderBy, take, skip}: GetProductsInput) {
-  const products = await db.product.findMany({
+export default async function getProjectsInfinite({
+  where,
+  orderBy,
+  take,
+  skip,
+}: GetProjectsInfiniteInput) {
+  const projects = await db.project.findMany({
     where,
     orderBy,
     take,
     skip,
   })
 
-  const count = await db.product.count()
-  const hasMore = skip + take < count
-  const nextPage = hasMore ? {take, skip: skip + take} : null
+  const count = await db.project.count()
+  const hasMore = skip! + take! < count
+  const nextPage = hasMore ? {take, skip: skip! + take!} : null
 
   return {
-    products,
+    projects,
     nextPage,
   }
 }

--- a/docs/use-paginated-query.mdx
+++ b/docs/use-paginated-query.mdx
@@ -6,19 +6,16 @@ sidebar_label: usePaginatedQuery
 ### Example
 
 ```ts
-import {Suspense, useState} from "react"
-import {Link, BlitzPage, usePaginatedQuery} from "blitz"
-import getProjects from "app/projects/queries/getProjects"
+import {usePaginatedQuery} from "blitz"
+import getProjectsPaginated from "app/projects/queries/getProjectsPaginated"
 
 const ITEMS_PER_PAGE = 3
-
 const Projects = () => {
   const [page, setPage] = useState(0)
-  const [projects] = usePaginatedQuery(getProjects, {
+  const [{projects, hasMore}] = usePaginatedQuery(getProjectsPaginated, {
     skip: ITEMS_PER_PAGE * page,
     take: ITEMS_PER_PAGE,
   })
-
   return (
     <div>
       {projects.map((project) => (
@@ -31,24 +28,36 @@ const Projects = () => {
       <button disabled={page === 0} onClick={() => setPage(page - 1)}>
         Previous
       </button>
-      <button disabled={projects.length !== ITEMS_PER_PAGE} onClick={() => setPage(page + 1)}>
+      <button disabled={!hasMore} onClick={() => setPage(page + 1)}>
         Next
       </button>
     </div>
   )
 }
+```
 
-const Page: BlitzPage = function () {
-  return (
-    <div>
-      <h1>Projects - Paginated</h1>
-      <Suspense fallback={<div>Loading...</div>}>
-        <Projects />
-      </Suspense>
-    </div>
-  )
+And here's the query to work with that:
+
+```ts
+export default async function getProjects(
+  {where, orderBy, cursor, take, skip}: GetProjectsInput,
+  ctx: Record<any, any> = {},
+) {
+  const projects = await db.project.findMany({
+    where,
+    orderBy,
+    take,
+    skip,
+  })
+
+  const count = await db.project.count()
+  const hasMore = skip! + take! < count
+
+  return {
+    projects,
+    hasMore,
+  }
 }
-export default Page
 ```
 
 ## API


### PR DESCRIPTION
I have updated the docs for usePaginatedQuery and useInfiniteQuery. Both of them now reference the projects db table (rather than products) so anyone can copy/paste the code into a new blitz project.

The usePaginatedQuery example has been updated to calculate the hasMore logic on the server, in line with bug fix #858 in the blitz repo.