### PR TITLE
Updated "Deploy To Render" Yaml to include Key of NODE_ENV

### DIFF
--- a/docs/deploy-render.mdx
+++ b/docs/deploy-render.mdx
@@ -53,6 +53,8 @@ services:
     buildCommand: yarn; blitz db migrate; blitz build
     startCommand: blitz start --production -H 0.0.0.0
     envVars:
+      - key: NODE_ENV
+        value: production
       - key: DATABASE_URL
         fromDatabase:
           name: myapp-db


### PR DESCRIPTION
Updated the example YAML to include a new key/value pair that fixed deploy issues I was having when deploying to render.com

Snippet added:
```
   envVars:
      - key: NODE_ENV
        value: production
```

The fix was suggested by @flybayer and the slack message is [here](https://blitzjs.slack.com/archives/C011EQ0J75M/p1597416891168400?thread_ts=1597383102.161700&cid=C011EQ0J75M)
