### PR TITLE
Add "no-git" switch documentation for "blitz new" 

### DIFF
--- a/docs/cli-new.mdx
+++ b/docs/cli-new.mdx
@@ -19,6 +19,7 @@ blitz new [name]
 | ----------- | --------- | --------------------------------------------------------------------------------------------------------------- | ------- |
 | `--npm`     |           | Uses `npm` as the project's package manager. If omitted, the project will default to `yarn` if it is installed. | `false` |
 | `--dry-run` | `-d`      | Displays what files would be generated but does not write the files to disk.                                    | `false` |
+| `--no-git`  |           | Skips git repository creation.                                                                                  | `false` |
 
 #### Examples
 


### PR DESCRIPTION
Adds documentation for a `--no-git` switch/flag for `blitz new`. 

Depends on https://github.com/blitz-js/blitz/pull/905. 