### PR TITLE
Database is now inferred from the DATABASE_URL

### DIFF
--- a/docs/deploy-render.mdx
+++ b/docs/deploy-render.mdx
@@ -26,22 +26,9 @@ services:
     startCommand: blitz start --production -H 0.0.0.0
 ```
 
-#### With postgres database:
+#### With Postgres database:
 
-You first need to change the defined datasource in `db/schema.prisma` from SQLite to Postgres
-
-```diff
--datasource sqlite {
--  provider = "sqlite"
-- url      = "file:./db.sqlite"
--
-+datasource postgresql {
-+  provider = "postgresql"
-+  url      = env("DATABASE_URL")
-+}
-```
-
-Lastly, use this `render.yaml`:
+Update your `render.yaml` to provide the `DATABASE_URL` environment variable to connect to your database:
 
 ```yaml
 # render.yaml


### PR DESCRIPTION
We no longer have separate datasources for SQLite/PostgreSQL - it's inferred from the `DATABASE_URL` environment variable.

This updates the Render.com docs to reflect that simplification. 