### PR TITLE
Added region to render template

### DIFF
--- a/docs/deploy-render.mdx
+++ b/docs/deploy-render.mdx
@@ -35,6 +35,7 @@ Update your `render.yaml` to provide the `DATABASE_URL` environment variable to 
 services:
   - type: web
     name: myapp
+    region: oregon
     env: node
     plan: starter
     buildCommand: yarn; blitz db migrate; blitz build
@@ -49,5 +50,6 @@ services:
 
 databases:
   - name: myapp-db
+    region: oregon
     plan: starter
 ```


### PR DESCRIPTION
Since the webapp and the database needs to be in the same region for the `DATABASE_URL` to work without hassle, I added it