### PR TITLE
Fix blitz install alias

### DIFF
--- a/docs/cli-install.mdx
+++ b/docs/cli-install.mdx
@@ -3,7 +3,7 @@ title: blitz install
 sidebar_label: blitz install
 ---
 
-**Alias: `blitz g`**
+**Alias: `blitz i`**
 
 Use this command to install a Blitz Recipe into your project.
 


### PR DESCRIPTION
- Docs show `g` but it should be `i`