### PR TITLE
Changing broken link to passport.js

### DIFF
--- a/docs/passportjs.mdx
+++ b/docs/passportjs.mdx
@@ -3,7 +3,7 @@ title: Passport.js
 sidebar_label: Passport.js
 ---
 
-Blitz provides an adapter that lets you use an existing [Passport.js authentication strategy](http://www.passportjs.org/packages/).
+Blitz provides an adapter that lets you use an existing [Passport.js authentication strategy](http://www.passportjs.org/).
 
 Currently only passport strategies that use a `verify` callback are supported. In the Twitter example below, the second argument to `TwitterStrategy()` is the `verify` callback.
 


### PR DESCRIPTION
The current link to passport.js doesn't work due to something wrong on their side. I've changed it to their home page instead so that it doesn't require a google search to find them.

If possible, please add the `hacktoberfest-accepted` label to the PR :).