### PR TITLE
Fix casing in Slack and GitHub

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -34,7 +34,7 @@ The Blitzjs.com website and documentation repo also has issues with [`ready to w
 - Performance or security improvements
 - Educational content like blogs, videos, courses
 
-If there's some other way you'd like to contribute, ask us about it in slack!
+If there's some other way you'd like to contribute, ask us about it in Slack!
 
 After you contribute in any way, please add yourself as a contributor via the [@all-contributors bot](https://allcontributors.org/docs/en/bot/usage)!
 
@@ -56,7 +56,7 @@ Lastly, you will be added the all-contributors list as an official Blitz contrib
 
 ## Project Management
 
-We use a [Github Project Board](https://github.com/blitz-js/blitz/projects/2) to track all issues and PRs.
+We use a [GitHub Project Board](https://github.com/blitz-js/blitz/projects/2) to track all issues and PRs.
 
 ## Commit Access
 

--- a/docs/how-the-community-operates.mdx
+++ b/docs/how-the-community-operates.mdx
@@ -17,17 +17,17 @@ All other contributors help in their free time. We now have [over 120 total cont
 
 ## Where to Ask Questions
 
-First, search [the Blitz slack](https://slack.blitzjs.com) and [the Github repo](https://github.com/blitz-js/blitz) so see if someone has already asked your question.
+First, search [the Blitz Slack](https://slack.blitzjs.com) and [the GitHub repo](https://github.com/blitz-js/blitz) so see if someone has already asked your question.
 
-Next, [post your question in our Discussion Forum](https://github.com/blitz-js/blitz/discussions). This is much better than slack as it's easier for people to find and link to.
+Next, [post your question in our Discussion Forum](https://github.com/blitz-js/blitz/discussions). This is much better than Slack as it's easier for people to find and link to.
 
-Then you're welcome to post a link to your Discussion thread in slack, because Github Discussions don't have a Slack notification integration yet.
+Then you're welcome to post a link to your Discussion thread in Slack, because GitHub Discussions don't have a Slack notification integration yet.
 
 🙏 As you gain experience with Blitz, please help answer other peoples questions!
 
 ## How to Report a Bug
 
-First, [search existing Github issues](https://github.com/blitz-js/blitz/issues?q=is%3Aissue) so see if someone has already reported your issue.
+First, [search existing GitHub issues](https://github.com/blitz-js/blitz/issues?q=is%3Aissue) so see if someone has already reported your issue.
 
 If not, then please [open a new issue](https://github.com/blitz-js/blitz/issues/new/choose)! Someone will usually reply to your new issue within a day or two.
 
@@ -35,7 +35,7 @@ If not, then please [open a new issue](https://github.com/blitz-js/blitz/issues/
 
 Currently the core team is working on getting to 1.0, which mostly means smoothing rough edges and fixing bugs. However, anyone else is more than welcome to continue adding major features!
 
-Our [Github issues](https://github.com/blitz-js/blitz/issues) are where you can find our roadmap. Many planned features have github issues, but not necessarily all of them do.
+Our [GitHub issues](https://github.com/blitz-js/blitz/issues) are where you can find our roadmap. Many planned features have github issues, but not necessarily all of them do.
 
 ## How to Propose Features/Changes
 
@@ -43,11 +43,11 @@ We love ideas and suggestions for how to make Blitz better! But please keep in m
 
 ### Minor Changes
 
-For minor changes like adding a new CLI flag or something, simply [open a new Github issue](https://github.com/blitz-js/blitz/issues/new/choose).
+For minor changes like adding a new CLI flag or something, simply [open a new GitHub issue](https://github.com/blitz-js/blitz/issues/new/choose).
 
 ### Everything Else: RFCs
 
-For any other features, even as small as adding a single new React hook, please post your request as an RFC (Request for Comments) as a [Github Discussion Thread](https://github.com/blitz-js/blitz/discussions/category_choices).
+For any other features, even as small as adding a single new React hook, please post your request as an RFC (Request for Comments) as a [GitHub Discussion Thread](https://github.com/blitz-js/blitz/discussions/category_choices).
 
 To post an RFC, do the following:
 
@@ -62,7 +62,7 @@ To post an RFC, do the following:
 
 As a member of the Blitz community, we value your input, ideas, suggestions, and help!
 
-Please feel very welcome to comment on any Github issue, pull request, RFC, etc! The community as a whole gets to shape where Blitz goes!
+Please feel very welcome to comment on any GitHub issue, pull request, RFC, etc! The community as a whole gets to shape where Blitz goes!
 
 As you gain experience, we greatly appreciate your help including but not limited to, answering people's questions, reviewing PRs, improving documentation, submitting PRs, etc.
 
@@ -88,7 +88,7 @@ We also **really appreciate when companies who use Blitz pay their employees** t
 
 The Blitz core team consists of people who are deeply invested in Blitz. Currently all core team members have been involved since day 1. (well probably day 10, but you get the idea :). The first 3 core members were chosen from the initial contributors. Going forward, diversity will be a key decision in selecting new core team members.
 
-The core team has Github, Slack, and npm admin permissions.
+The core team has GitHub, Slack, and npm admin permissions.
 
 <table>
   <tr>

--- a/docs/maintainers.mdx
+++ b/docs/maintainers.mdx
@@ -22,7 +22,7 @@ The primary responsibilities of level 1 maintainers are:
 - Being a friendly, welcoming voice for the Blitz community
 - Issue triage
 - Pull request triage
-- Monitor and answer the `#-help` slack channel
+- Monitor and answer the `#-help` Slack channel
 - Following up on assigned issues to make sure they are being worked on
 - Following up on in-progress PRs to make sure they don't get stuck
 - Community encouragement
@@ -55,8 +55,7 @@ Some especially important points:
 - **Gratitude:** immediately express gratitude when someone opens an issue or PR. This takes effort/time and we appreciate it
 - **Responsiveness:** during issue/PR triage, even if we can’t do a full review right away, leave a comment thanking them and saying we’ll review it soon
 - **Understanding:** it's critical to ensure you understand exactly what someone is saying before you respond. Ask plenty of questions if needed. It's very bad if someone has to reply to your response and say "actually I was asking about X"
-  - In fact, at least one question is almost always required before you can respond appropriately  — whether in Github or in Slack
-  
+  - In fact, at least one question is almost always required before you can respond appropriately  — whether in GitHub or in Slack
 
 ### Resources
 
@@ -100,14 +99,14 @@ If someone that's not a maintainer post in the wrong area, that's fine. Don't te
 ### Actions
 
 1. Kindly request any changes if needed
-2. Else add a Github approval so that level 2 maintainers know it's already had an initial review
+2. Else add a GitHub approval so that level 2 maintainers know it's already had an initial review
 
 ## Final PR Review & Merging (Level 2 maintainers)
 
 As a level 2 maintainer, it is your responsibility to make sure broken code and regressions never reach the canary branch.
 
 1. Ensure the PR'ed code fully works as intended and that there are no regressions in related code
-   1. If not fully covered by automated tests, you need to pull down the code locally and manually verify everything (the Github CLI helps with this!)
+   1. If not fully covered by automated tests, you need to pull down the code locally and manually verify everything (the GitHub CLI helps with this!)
 2. During squash & merge:
    1. Change the commit title to be public friendly - this exact text will go in the release notes
    2. Add the commit type in the description, in parenthesis like `(patch)`. Commit types:

--- a/docs/passportjs.mdx
+++ b/docs/passportjs.mdx
@@ -58,7 +58,9 @@ export default passportAuth({
   successRedirectUrl: "/",
   errorRedirectUrl: "/",
   secureProxy: true, // highlight-line
-  strategies: [/*...*/],
+  strategies: [
+    /*...*/
+  ],
 })
 ```
 
@@ -178,7 +180,7 @@ There are four different ways to determine the redirect URL where a user should 
 
 Note: If there is an error, methods #1 and #2 will override `config.errorRedirectUrl`
 
-This should give you maximum flexibility to do anything you need. If this doesn't meet your needs, please open an issue on Github!
+This should give you maximum flexibility to do anything you need. If this doesn't meet your needs, please open an issue on GitHub!
 
 ### `authenticateOptions`
 

--- a/src/components/DocItem/index.js
+++ b/src/components/DocItem/index.js
@@ -116,7 +116,7 @@ function DocItem(props) {
                     <div className="col">
                       Idea for improving this page?
                       <a href={editUrl} target="_blank" rel="noreferrer noopener" sx={{ml: 2}}>
-                        Edit it on Github
+                        Edit it on GitHub
                       </a>
                     </div>
                     {(lastUpdatedAt || lastUpdatedBy) && (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -153,7 +153,7 @@ function Home() {
               href="https://github.com/blitz-js/blitz"
               sx={{variant: "buttons.outline", fontSize: 3}}
             >
-              Github
+              GitHub
             </Link>
           </Spaced>
         </Spaced>


### PR DESCRIPTION
I didn't like how GitHub was misspelt on the main page so thought I'd contribute this little fix. Whilst looking for `Github`, I also spotted Slack in lowercase and fixed it too.
 
## Before

![image](https://user-images.githubusercontent.com/2852660/95635804-2827c800-0a96-11eb-968d-fe6ac231c1dc.png)

## After

![image](https://user-images.githubusercontent.com/2852660/95636373-a46edb00-0a97-11eb-965a-10eadf307651.png)

If you decide to accept this PR and it's not too much of an ask, could you label the PR with `hacktoberfest-accepted`?
