### PR TITLE
Fix typo in database overview page

### DIFF
--- a/docs/database-overview.mdx
+++ b/docs/database-overview.mdx
@@ -72,7 +72,7 @@ volumes:
   data:
 ```
 
-2. Inside your `.env.local` file add 3 new environemnt variables which are required by docker
+2. Inside your `.env.local` file add 3 new environment variables which are required by docker
 
 ```text
 POSTGRES_USER=your_user


### PR DESCRIPTION
Fixes the spelling of "environment" in the docs.