### PR TITLE
Add documentation for setQueryData

### DIFF
--- a/docs/mutation-usage.mdx
+++ b/docs/mutation-usage.mdx
@@ -45,14 +45,14 @@ Any errors thrown from your server code will be thrown on the client exactly lik
 
 ## Cache Invalidation
 
-#### `mutate()`
+#### `setQueryData()`
 
-- [`useQuery`](./use-query.mdx) returns a `mutate` function you can use to manually update the cache
-- Calling `mutate` will automatically trigger a refetch for the initial query to ensure it has the correct data. Disable refetch by passing an options object `{refetch: false}` as the second argument.
+- [`useQuery`](./use-query.mdx) returns a `setQueryData` function you can use to manually update the cache
+- Calling `setQueryData` will automatically trigger a refetch for the initial query to ensure it has the correct data. Disable refetch by passing an options object `{refetch: false}` as the second argument.
 
 ```tsx
 export default function (props: {query: {id: number}}) {
-  const [product, {mutate}] = useQuery(getProduct, {where: {id: props.query.id}})
+  const [product, {setQueryData}] = useQuery(getProduct, {where: {id: props.query.id}})
   const [updateProjectMutation] = useMutation(updateProject)
 
   return (
@@ -61,7 +61,7 @@ export default function (props: {query: {id: number}}) {
       onSubmit={async (values) => {
         try {
           const product = await updateProjectMutation(values)
-          mutate(product)
+          setQueryData(product)
         } catch (error) {
           alert("Error saving product")
         }
@@ -142,7 +142,7 @@ Here's a simple form component with an `onSubmit` function that calls an `update
 
 ```tsx
 export default function (props: {query: {id: number}}) {
-  const [product, {mutate}] = useQuery(getProduct, {where: {id: props.query.id}})
+  const [product, {setQueryData}] = useQuery(getProduct, {where: {id: props.query.id}})
   const [updateProjectMutation] = useMutation(updateProject)
 
   return (
@@ -151,7 +151,7 @@ export default function (props: {query: {id: number}}) {
       onSubmit={async (values) => {
         try {
           const product = await updateProjectMutation(values)
-          mutate(product)
+          setQueryData(product)
         } catch (error) {
           alert("Error saving product")
         }
@@ -164,11 +164,11 @@ export default function (props: {query: {id: number}}) {
 ```
 
 We can enhance this to support instant feedback to the user, immediately showing the edited product information, by mutating the local cache of the `getProducts` query with the changes we're about to send to the database.
-We pass `{refetch: false}` as a second argument to the mutate() function to prevent the mutation triggering a refetch of stale data while we wait for the response.
+We pass `{refetch: false}` as a second argument to the setQueryData() function to prevent the mutation triggering a refetch of stale data while we wait for the response.
 
 ```tsx
 export default function (props: {query: {id: number}}) {
-  const [product, {mutate}] = useQuery(getProduct, {where: {id: props.query.id}})
+  const [product, {setQueryData}] = useQuery(getProduct, {where: {id: props.query.id}})
   const [updateProjectMutation] = useMutation(updateProject)
 
   return (
@@ -177,13 +177,13 @@ export default function (props: {query: {id: number}}) {
       onSubmit={async (values) => {
         try {
           // Update local cache with form values without triggering refetch
-          mutate(values, {refetch: false}) // highlight-line
+          setQueryData(values, {refetch: false}) // highlight-line
           const product = await updateProjectMutation(values)
           // Update local cache with result, then refetch
-          mutate(product)
+          setQueryData(product)
         } catch (error) {
           // Set cache back to original result, then refetch
-          mutate(product) // highlight-line
+          setQueryData(product) // highlight-line
           alert("Error saving product")
         }
       }}

--- a/docs/resolver-utilities.mdx
+++ b/docs/resolver-utilities.mdx
@@ -101,3 +101,65 @@ const queryKey = getQueryKey(resolver, inputArgs?)
 
 - `results`
   - The exact results returned from the resolver
+
+## `setQueryData`
+
+Works the same as the [setQueryData returned by useQuery](./use-query#setQueryData). The difference is that it's not bound to the
+useQuery and expects the `resolver` and the `inputArgs` instead. It will also invalidate the query causing a refetch.
+Disable refetch by passing an options object `{refetch: false}` as the `opts` argument.
+
+### Example
+
+```tsx
+import {setQueryData} from "blitz"
+
+export default function (props: {query: {id: number}}) {
+  const [product] = useQuery(getProduct, {where: {id: props.query.id}})
+  const [updateProjectMutation] = useMutation(updateProject)
+
+  return (
+    <Formik
+      initialValues={product}
+      onSubmit={async (values) => {
+        try {
+          const product = await updateProjectMutation(values)
+          setQueryData(getProduct, {where: {id: props.query.id}}, product)
+        } catch (error) {
+          alert("Error saving product")
+        }
+      }}
+    >
+      {/* ... */}
+    </Formik>
+  )
+}
+```
+
+## API
+
+<!-- prettier-ignore -->
+```js
+const promise = setQueryData(resolver, inputArgs, newData, opts?)
+```
+
+### Arguments
+
+- `resolver:` A Blitz [query resolver](./query-resolvers).
+  - **Required**
+- `inputArgs`
+  - **Required**
+  - The arguments that will be passed to `resolver`
+  - It will set the data for the specified `resolver` and `inputArgs` combination
+- `newData`
+  - **Required**
+  - If non-function is passed, the data will be updated to this value
+  - If a function is passed, it will receive the old data value and be expected to return a new one.
+- `opts`
+  - Optional
+  - An object with additional options.
+  - Disable refetch by passing an options object `{refetch: false}`.
+
+### Returns
+
+- `results`
+  - Returns a promise that will be resolved when the new data is refetched.

--- a/docs/use-infinite-query.mdx
+++ b/docs/use-infinite-query.mdx
@@ -76,7 +76,7 @@ const [
     refetch,
     fetchMore,
     canFetchMore,
-    mutate,
+    setQueryData,
   }
 ] = useQuery(queryResolver, getQueryInputArguments, {
   getFetchMore: (lastPage, allPages) => fetchMoreVariable
@@ -132,9 +132,9 @@ The options are identical to the options for the [useQuery hook](./use-query.mdx
   - previous option which will determine if the data you are fetching is should be prepended instead of appended to your infinite list. e.g. `fetchMore(nextPageVars, { previous: true })`
 - `canFetchMore: Boolean`
   - If using `paginated` mode, this will be `true` if there is more data to be fetched (known via the required `getFetchMore` option function).
-- `mutate()` - `Function(newData, opts) => void`
+- `setQueryData()` - `Function(newData, opts) => void`
   - A function to manually update the cache for a query.
   - `newData` can be an object of new data or a function that receives the old data and returns the new data
   - This is often used to instantly update the cache after submitting a form
   - After updating the cache, this will automatically call `refetch()` to ensure the data is correct. Disable refetch by passing an options object `{refetch: false}` as the second argument.
-  - See the [Blitz mutation usage docs](./mutation-usage#mutate) for example usage of `mutate()`
+  - See the [Blitz mutation usage docs](./mutation-usage#setQueryData) for example usage of `setQueryData()`

--- a/docs/use-paginated-query.mdx
+++ b/docs/use-paginated-query.mdx
@@ -123,3 +123,9 @@ The options are identical to the options for the [useQuery hook](./use-query.mdx
   - A function to manually refetch the query if it is stale.
   - To bypass the stale check, you can pass the `force: true` option and refetch it regardless of it's freshness
   - If the query errors, the error will only be logged. If you want an error to be thrown, pass the `throwOnError: true` option
+- `setQueryData()` - `Function(newData, opts) => void`
+  - A function to manually update the cache for a query.
+  - `newData` can be an object of new data or a function that receives the old data and returns the new data
+  - This is often used to instantly update the cache after submitting a form
+  - After updating the cache, this will automatically call `refetch()` to ensure the data is correct. Disable refetch by passing an options object `{refetch: false}` as the second argument.
+  - See the [Blitz mutation usage docs](./mutation-usage#setQueryData) for example usage of `setQueryData()`

--- a/docs/use-query.mdx
+++ b/docs/use-query.mdx
@@ -50,7 +50,7 @@ const [
     isFetching,
     failureCount,
     refetch,
-    mutate,
+    setQueryData,
   }
 ] = useQuery(queryResolver, queryInputArguments, {
   manual,
@@ -172,9 +172,9 @@ const [
   - A function to manually refetch the query if it is stale.
   - To bypass the stale check, you can pass the `force: true` option and refetch it regardless of it's freshness
   - If the query errors, the error will only be logged. If you want an error to be thrown, pass the `throwOnError: true` option
-- `mutate()` - `Function(newData, opts) => Promise<void>`
+- `setQueryData()` - `Function(newData, opts) => Promise<void>`
   - A function to manually update the cache for a query.
   - `newData` can be an object of new data or a function that receives the old data and returns the new data
   - This is often used to instantly update the cache after submitting a form
   - After updating the cache, this will automatically call `refetch()` to ensure the data is correct. Disable refetch by passing an options object `{refetch: false}` as the second argument.
-  - See the [Blitz mutation usage docs](./mutation-usage#mutate) for example usage of `mutate()`
+  - See the [Blitz mutation usage docs](./mutation-usage#setQueryData) for example usage of `setQueryData()`


### PR DESCRIPTION
Adding documentation for `setQueryData` added on https://github.com/blitz-js/blitz/pull/1291