### PR TITLE
fix: docker.compose.yml to docker-compose.yml

### DIFF
--- a/docs/database-overview.mdx
+++ b/docs/database-overview.mdx
@@ -54,7 +54,7 @@ datasource db {
 
 One way to get a PostgreSQL database on your machine is to run PostgreSQL inside a docker container.
 
-1. Create a `docker.compose.yml` file inside the root of your project with the following content
+1. Create a `docker-compose.yml` file inside the root of your project with the following content
 
 ```yaml
 version: "3.7"


### PR DESCRIPTION
default path is: `./docker-compose.yml`, not `./docker.compose.yml`

https://docs.docker.com/compose/compose-file/#service-configuration-reference