### PR TITLE
Fix example for connect middleware

### DIFF
--- a/docs/middleware.mdx
+++ b/docs/middleware.mdx
@@ -159,7 +159,11 @@ Blitz provides a `connectMiddleware()` function that converts connect middleware
 ```ts
 // blitz.config.js
 const {connectMiddleware} = require("blitz")
-const cors = require("cors")
+const Cors = require("cors")
+
+const cors = Cors({
+  methods: ["GET", "POST", "HEAD", "OPTIONS"]
+});
 
 module.exports = {
   middleware: [connectMiddleware(cors)],


### PR DESCRIPTION
The example for the connect middleware uses the `cors` handler which actually exports a constructor. So it needs to be called before being used.