### PR TITLE
Add deploy to heroku instructions

### DIFF
--- a/docs/deploy-heroku.mdx
+++ b/docs/deploy-heroku.mdx
@@ -2,3 +2,70 @@
 title: Deploy to a Server on Heroku
 sidebar_label: To Heroku
 ---
+
+:::info
+This guide assumes the following;
+
+1. That you already have an Heroku account
+2. That you’ll be using the Heroku Postgres addon (since Heroku does not provide sqlite as a suitable addon)
+3. That the application is a completely new application created using the [Blitz CLI](/docs/cli-new).
+4. That deployments will be made with git and the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
+
+:::
+
+**In Heroku:**
+
+1. Create a new application in your desired region
+2. Attach the [Heroku Postgres addon](https://elements.heroku.com/addons/heroku-postgresql) to your application.
+
+**In your terminal:**
+
+1. Login to Heroku using
+
+```
+heroku login
+```
+
+2. Add your Heroku app as a git remote with the following command replacing `<APP_NAME>` with the name you provided or that was given to you when creating the Heroku app.
+
+```
+heroku git:remote --app <APP_NAME>
+```
+
+**In your Blitz application:**
+
+1. Configure the application to use postgres instead of the default sqlite by following the [“Switch to PostgreSQL” guide](/docs/database-overview#switch-to-postgresql).
+2. In your package.json add a `start:production` and an `heroku-postbuild` command. This command is what Heroku will run when building your application for deploy. So we’ll use it to migrate any database changes and to build a production bundle of your app.
+
+```diff
+"scripts": {
++   "start:production": "blitz start --production --port $PORT",
++   "heroku-postbuild": "blitz db migrate && blitz build --production"
+}
+```
+
+3. Create a `Procfile` file inside the root of your project with the following content
+
+```
+web: npm run start:production
+```
+
+**Deploy using git:**
+
+With these changes committed, to deploy your application, run:
+
+```
+git push heroku master
+```
+
+Once built you can open your application with the following command in your terminal
+
+```
+heroku open
+```
+
+_Note:_ While the application should now be working you will not be able to use authentication until you provide Heroku with a `SESSION_SECRET_KEY` envivonment variable. You can do this with the following command replacing `<MY_SECRET>` with your secret (at least 32 characters long)
+
+```
+heroku config:set SESSION_SECRET_KEY=<SESSION_SECRET_KEY>
+```

--- a/docs/deploy-heroku.mdx
+++ b/docs/deploy-heroku.mdx
@@ -1,0 +1,4 @@
+---
+title: Deploy to a Server on Heroku
+sidebar_label: To Heroku
+---

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,7 +53,7 @@ module.exports = {
     ],
     Mutations: ["mutation-resolvers", "mutation-usage", "use-mutation"],
     "Queries & Mutations": ["invoke", "resolver-utilities"],
-    "Deploying to Production": ["deploy-heroku", "deploy-render", "deploy-vercel"],
+    "Deploying to Production": ["deploy-render", "deploy-vercel", "deploy-heroku"],
     CLI: [
       "cli-overview",
       "cli-new",

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,7 +53,7 @@ module.exports = {
     ],
     Mutations: ["mutation-resolvers", "mutation-usage", "use-mutation"],
     "Queries & Mutations": ["invoke", "resolver-utilities"],
-    "Deploying to Production": ["deploy-render", "deploy-vercel"],
+    "Deploying to Production": ["deploy-heroku", "deploy-render", "deploy-vercel"],
     CLI: [
       "cli-overview",
       "cli-new",


### PR DESCRIPTION
This PR adds a page with instructions on how to deploy a new Blitz application to Heroku using Heroku Postgres. It closes #239.

I’m a little torn about these instructions, I’m not sure I’m completely happy with how much it seems to rely on the reader knowing about Heroku, its CLI, and pushing to it using git. I don’t want it to be a guide about creating applications on Heroku but also don’t want to assume that the reader is experienced with this.

Any pointers or improvements would be great.

<details>
<summary>Page screenshot</summary>

![localhost_3000_docs_deploy-heroku](https://user-images.githubusercontent.com/11544418/97993535-7c4b7100-1de4-11eb-8729-f71d5ea2472c.png)


</details>