### PR TITLE
removed versioning section from READMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,6 @@ The `main` branch is automatically deployed to https://blitzjs.com
 
 We're setting up this repo to support language translations as soon as folks step up to do so. We plan to follow the same process as the reactjs.com translations.
 
-## Versioning
-
-When we are ready to tag a new version of the docs we can run the docusaurus scripts.
-
-```
-yarn run docusaurus docs:version 1.1.0
-```
-
-When tagging a new version, the document versioning mechanism will:
-
-1. Copy the full docs/ folder contents into a new versioned_docs/version-/ folder.
-2. Create a versioned sidebars file based from your current sidebar configuration (if it exists). Saved it as versioned_sidebars/version--sidebars.json.
-3. Append the new version number into versions.json.
-
-[See the Docusaurus documention on versioning](https://v2.docusaurus.io/docs/versioning/#tagging-a-new-version)
-
 ## Code Syntax Highlights
 
 Code blocks are syntax highlighted using Prism. You can call attention to specific sections in a code block using comments to begin and end a block `// highlight-start` `// highlight-end`, or highlight a single line `// highlight-line`


### PR DESCRIPTION
I was updating the docs before and was following the READMe to update the version of the docs like it described. However, I later found out we don't need that section. This PR is to remove it to help reduce confusion.

Closes #266 