### PR TITLE
master is replaced by main in new github project

### DIFF
--- a/docs/deploy-heroku.mdx
+++ b/docs/deploy-heroku.mdx
@@ -55,7 +55,7 @@ web: npm run start:production
 With these changes committed, to deploy your application, run:
 
 ```
-git push heroku master
+git push heroku main
 ```
 
 Once built you can open your application with the following command in your terminal


### PR DESCRIPTION
Since most people following the guide may have just created a fresh project hosted on Github, maybe we could suggest `main` instead of `master`. 