### PR TITLE
Fix invalid syntax in API routes auth code example

### DIFF
--- a/docs/api-routes.mdx
+++ b/docs/api-routes.mdx
@@ -49,13 +49,13 @@ You can use the `getSessionContext` function to get the session of the user. Her
 ```ts
 import {getSessionContext} from "@blitzjs/server"
 
-export default const customRoute = async (req, res) => {
+export default async (req, res) => {
   const session = await getSessionContext(req, res)
   console.log("User ID:", session.userId)
 
   res.statusCode = 200
   res.setHeader("Content-Type", "application/json")
-  res.end(JSON.stringify({ userId: session.userId }))
+  res.end(JSON.stringify({userId: session.userId}))
 }
 ```
 

--- a/docs/api-routes.mdx
+++ b/docs/api-routes.mdx
@@ -49,7 +49,7 @@ You can use the `getSessionContext` function to get the session of the user. Her
 ```ts
 import {getSessionContext} from "@blitzjs/server"
 
-export default async (req, res) => {
+export default async function customRoute(req, res) {
   const session = await getSessionContext(req, res)
   console.log("User ID:", session.userId)
 


### PR DESCRIPTION
I was following the docs to authenticate through an API route and realized ```export default const`` in the code example is not valid after posting it in my code editor. This a small edit to clean it up. 

<table>
  <tr>
    <th>
     Before
     </th>
     <th>
     After
     </th>
  <tr>
  <tr>
    <td>
    <img width="820" alt="Screen Shot 2020-11-25 at 4 13 58 PM" src="https://user-images.githubusercontent.com/8839514/100282326-64759180-2f39-11eb-98d0-5457dbddeeba.png">
   </td>
<td>
<img width="857" alt="Screen Shot 2020-11-25 at 4 17 32 PM" src="https://user-images.githubusercontent.com/8839514/100282551-d2ba5400-2f39-11eb-8e3c-534f72f7198e.png"> 
  </tr>
</td>
</table>  
