### PR TITLE
Remove `manual` option occurrences

### DIFF
--- a/docs/use-infinite-query.mdx
+++ b/docs/use-infinite-query.mdx
@@ -116,7 +116,6 @@ The options are identical to the options for the [useQuery hook](./use-query.mdx
 ##### `queryExtras: Object`
 
 - `isFetching: Boolean`
-  - Defaults to `true` so long as `manual` is set to `false`
   - Will be `true` if the query is currently fetching, including background fetching.
 - `failureCount: Integer`
   - The failure count for the query.

--- a/docs/use-paginated-query.mdx
+++ b/docs/use-paginated-query.mdx
@@ -113,7 +113,6 @@ The options are identical to the options for the [useQuery hook](./use-query.mdx
   - The actual data object for this query and its specific input arguments
   - When fetching an uncached query, this value will be `undefined`
 - `isFetching: Boolean`
-  - Defaults to `true` so long as `manual` is set to `false`
   - Will be `true` if the query is currently fetching, including background fetching.
 - `failureCount: Integer`
   - The failure count for the query.

--- a/docs/use-query.mdx
+++ b/docs/use-query.mdx
@@ -53,7 +53,6 @@ const [
     setQueryData,
   }
 ] = useQuery(queryResolver, queryInputArguments, {
-  manual,
   enabled,
   forceFetchOnMount,
   retry,
@@ -86,9 +85,6 @@ const [
 
 ### Options
 
-- `manual: Boolean`
-  - Set this to `true` to disable automatic refetching when the query mounts or input arguments change.
-  - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
 - `enabled: Boolean`
   - Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
   - To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -162,7 +158,6 @@ const [
 ##### `queryExtras: Object`
 
 - `isFetching: Boolean`
-  - Defaults to `true` so long as `manual` is set to `false`
   - Will be `true` if the query is currently fetching, including background fetching.
 - `failureCount: Integer`
   - The failure count for the query.


### PR DESCRIPTION
Remove `manual` option occurrences across queries pages since it seems to have been replaced by `enable`

![image](https://user-images.githubusercontent.com/5040476/100583831-8aa98180-32eb-11eb-81fe-ac3f7348ba6c.png)
