### PR TITLE
Remove bad example from Blitz Build docs

### DIFF
--- a/docs/cli-build.mdx
+++ b/docs/cli-build.mdx
@@ -16,7 +16,3 @@ None
 ```bash
 blitz build
 ```
-
-```bash
-blitz build -H 127.0.0.1 -p 5632
-```


### PR DESCRIPTION
Looks like it was an example that was copy+pasted from `blitz start`