### PR TITLE
Fix for "Listing Choices" portion of Tutorial

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -510,7 +510,10 @@ export default async function getQuestion({where /* include */}: GetQuestionInpu
 ```js
 // app/questions/queries/getQuestions.ts
 
-type GetQuestionsInput = Pick<FindManyQuestionArgs, "where" | "orderBy" | "cursor" | "take" | "skip">
+import { Ctx } from "blitz"
+import db, { Prisma } from "db"
+
+type GetQuestionsInput = Pick<Prisma.FindManyQuestionArgs, "where" | "orderBy" | "cursor" | "take" | "skip">
 
 export default async function getQuestions(
   {where, orderBy, cursor, take, skip}: GetQuestionsInput,


### PR DESCRIPTION
The current code causes an error because the "FindManyQuestionArgs" type comes from Prisma.

This will help tutorial users by preventing this error and explicitly showing that they need to keep the Prisma imports from the code they are replacing.