### PR TITLE
fix: fix outdated & incorrect code example

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -522,6 +522,7 @@ export default async function getQuestions(
     orderBy,
     take,
     skip,
+    include:{ choices:true}
   })
 
   const count = await db.question.count()
@@ -537,18 +538,7 @@ export default async function getQuestions(
 }
 ```
 
-Now hop back to our main questions page in your editor, and we can list the choices of each question.
-
-Add `include` option in `app/questions/queries/getQuestion.ts` to fetch `Question` data with its choices info:
-
-```
-const question = await db.question.findFirst({
-  where,
-  include: { choices: true }, // highlight-line
-})
-```
-
-Then add this code beneath the `Link` in our `QuestionsList`:
+Now hop back to our main questions page in your editor, and we can list the choices of each question. And add this code beneath the `Link` in our `QuestionsList`:
 
 ```jsx
 <ul>

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -522,7 +522,7 @@ export default async function getQuestions(
     orderBy,
     take,
     skip,
-    include:{ choices:true}
+    include:{ choices:true }
   })
 
   const count = await db.question.count()
@@ -630,7 +630,7 @@ import updateChoice from "app/choices/mutations/updateChoice" // highlight-line
 export const Question = () => {
   const router = useRouter()
   const questionId = useParam("questionId", "number")
-  const [question] = useQuery(getQuestion, {where: {id: questionId}}) // highlight-line
+  const [question, {refetch}] = useQuery(getQuestion, {where: {id: questionId}}) // highlight-line
   const [deleteQuestionMutation] = useMutation(deleteQuestion)
   const [updateChoiceMutation] = useMutation(updateChoice) // highlight-line
 
@@ -641,6 +641,7 @@ export const Question = () => {
         where: {id},
         data: {votes: votes + 1},
       })
+      refetch()
       alert("Success!" + JSON.stringify(updated))
     } catch (error) {
       alert("Error creating question " + JSON.stringify(error, null, 2))

--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -330,7 +330,7 @@ export const QuestionsList = () => {
     <ul>
       {questions.map((question) => (
         <li key={question.id}>
-          <Link href="/questions/[questionId]" as={`/questions/${question.id}`}>
+          <Link href={`/questions/${question.id}`}>
             <a>{question.text}</a> // highlight-line
           </Link>
         </li>
@@ -432,7 +432,8 @@ onSubmit={async (event) => {
 In the end, your page should look something like this:
 
 ```jsx
-import {Head, Link, useRouter, BlitzPage} from "blitz"
+import Layout from "app/layouts/Layout"
+import {Link, useRouter, useMutation, BlitzPage} from "blitz"
 import createQuestion from "app/questions/mutations/createQuestion"
 import QuestionForm from "app/questions/components/QuestionForm"
 
@@ -442,49 +443,44 @@ const NewQuestionPage: BlitzPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>New Question</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+      <h1>Create New Question</h1>
 
-      <main>
-        <h1>Create New Question </h1>
-
-        <QuestionForm
-          initialValues={{}}
-          // highlight-start
-          onSubmit={async (event) => {
-            try {
-              const question = await createQuestionMutation({
-                data: {
-                  text: event.target[0].value,
-                  choices: {
-                    create: [
-                      {text: event.target[1].value},
-                      {text: event.target[2].value},
-                      {text: event.target[3].value},
-                    ],
-                  },
+      <QuestionForm
+        initialValues={{}}
+        // highlight-start
+        onSubmit={async (event) => {
+          try {
+            const question = await createQuestionMutation({
+              data: {
+                text: event.target[0].value,
+                choices: {
+                  create: [
+                    {text: event.target[1].value},
+                    {text: event.target[2].value},
+                    {text: event.target[3].value},
+                  ],
                 },
-              })
-              alert("Success!" + JSON.stringify(question))
-              router.push("/questions/[questionId]", `/questions/${question.id}`)
-            } catch (error) {
-              alert("Error creating question " + JSON.stringify(error, null, 2))
-            }
-          }}
-          // highlight-end
-        />
+              },
+            })
+            alert("Success!" + JSON.stringify(question))
+            router.push("/questions/[questionId]", `/questions/${question.id}`)
+          } catch (error) {
+            alert("Error creating question " + JSON.stringify(error, null, 2))
+          }
+        }}
+        // highlight-end
+      />
 
-        <p>
-          <Link href="/questions">
-            <a>Questions</a>
-          </Link>
-        </p>
-      </main>
+      <p>
+        <Link href="/questions">
+          <a>Questions</a>
+        </Link>
+      </p>
     </div>
   )
 }
+
+NewQuestionPage.getLayout = (page) => <Layout title={"Create New Question"}>{page}</Layout>
 
 export default NewQuestionPage
 ```
@@ -513,32 +509,46 @@ export default async function getQuestion({where /* include */}: GetQuestionInpu
 import { Ctx } from "blitz"
 import db, { Prisma } from "db"
 
-type GetQuestionsInput = Pick<Prisma.FindManyQuestionArgs, "where" | "orderBy" | "cursor" | "take" | "skip">
+type GetQuestionsInput = Pick<Prisma.FindManyQuestionArgs, "where" | "orderBy" | "skip" | "take">
 
 export default async function getQuestions(
-  {where, orderBy, cursor, take, skip}: GetQuestionsInput,
-  ctx: Ctx,
+  { where, orderBy, skip = 0, take }: GetQuestionsInput,
+  ctx: Ctx
 ) {
   ctx.session.authorize()
 
   const questions = await db.question.findMany({
     where,
     orderBy,
-    cursor,
     take,
     skip,
-    include: {choices: true},
   })
 
   const count = await db.question.count()
   const hasMore = typeof take === "number" ? skip + take < count : false
   const nextPage = hasMore ? { take, skip: skip + take! } : null
 
-  return questions
+  return {
+    questions,
+    nextPage,
+    hasMore,
+    count,
+  }
 }
 ```
 
-Now hop back to our main questions page in your editor, and we can list the choices of each question. Add this code beneath the `Link` in our `QuestionsList`:
+Now hop back to our main questions page in your editor, and we can list the choices of each question.
+
+Add `include` option in `app/questions/queries/getQuestion.ts` to fetch `Question` data with its choices info:
+
+```
+const question = await db.question.findFirst({
+  where,
+  include: { choices: true }, // highlight-line
+})
+```
+
+Then add this code beneath the `Link` in our `QuestionsList`:
 
 ```jsx
 <ul>
@@ -620,8 +630,9 @@ Finally, we’ll tell our new `button` to call that function!
 To be sure, this is what all that should look like:
 
 ```jsx
-import React, {Suspense} from "react"
-import {Head, Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
+import {Suspense} from "react"
+import Layout from "app/layouts/Layout"
+import {Link, useRouter, useQuery, useParam, BlitzPage, useMutation} from "blitz"
 import getQuestion from "app/questions/queries/getQuestion"
 import deleteQuestion from "app/questions/mutations/deleteQuestion"
 import updateChoice from "app/choices/mutations/updateChoice" // highlight-line
@@ -629,7 +640,7 @@ import updateChoice from "app/choices/mutations/updateChoice" // highlight-line
 export const Question = () => {
   const router = useRouter()
   const questionId = useParam("questionId", "number")
-  const [question, {refetch}] = useQuery(getQuestion, {where: {id: questionId}}) // highlight-line
+  const [question] = useQuery(getQuestion, {where: {id: questionId}}) // highlight-line
   const [deleteQuestionMutation] = useMutation(deleteQuestion)
   const [updateChoiceMutation] = useMutation(updateChoice) // highlight-line
 
@@ -640,7 +651,7 @@ export const Question = () => {
         where: {id},
         data: {votes: votes + 1},
       })
-      refetch()
+      alert("Success!" + JSON.stringify(updated))
     } catch (error) {
       alert("Error creating question " + JSON.stringify(error, null, 2))
     }
@@ -658,7 +669,7 @@ export const Question = () => {
         ))}
       </ul>
       // highlight-end
-      <Link href="/questions/[questionId]/edit" as={`/questions/${question.id}/edit`}>
+      <Link href={`/questions/${question.id}/edit`}>
         <a>Edit</a>
       </Link>
       <button
@@ -679,24 +690,20 @@ export const Question = () => {
 const ShowQuestionPage: BlitzPage = () => {
   return (
     <div>
-      <Head>
-        <title>Question</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-      <main>
-        <p>
-          <Link href="/questions">
-            <a>Questions</a>
-          </Link>
-        </p>
+      <p>
+        <Link href="/questions">
+          <a>Questions</a>
+        </Link>
+      </p>
 
-        <Suspense fallback={<div>Loading...</div>}>
-          <Question />
-        </Suspense>
-      </main>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Question />
+      </Suspense>
     </div>
   )
 }
+
+ShowQuestionPage.getLayout = (page) => <Layout title={"Question"}>{page}</Layout>
 
 export default ShowQuestionPage
 ```


### PR DESCRIPTION
Closes: #293

- The `skip type definition` and `result return from getQuestions.ts` problem mentioned in the issue is my carelessness, content which generated from the latest version of BlitzJS works normally.

I found some other issues and  fix it, including: 
- `<Link />` component props:
- `include` options in getQuestion.ts
- keep up with latest generated contents
