### PR TITLE
Roll back the sentence to the original output

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -150,11 +150,9 @@ blitz generate all question text:string choices:choice[]
 >   text      String
 >   choices   Choice[]
 > }
-```
 
-Now run `blitz db migrate` to add this model to your database. You'll see the following output:
+Now run blitz db migrate to add this model to your database
 
-```
 CREATE    app/questions/pages/questions/index.tsx
 CREATE    app/questions/pages/questions/new.tsx
 CREATE    app/questions/pages/questions/[questionId]/edit.tsx


### PR DESCRIPTION
This PR reverts https://github.com/blitz-js/blitzjs.com/pull/297.

The sentence is actually a part of actual output of `blitz generate all question text:string choices:choice[]`. We need to run `blitz db migrate` after the second `blitz generate` command.