### PR TITLE
Fix typo in session-management.mdx and code block in document-component.mdx

### DIFF
--- a/docs/document-component.mdx
+++ b/docs/document-component.mdx
@@ -43,10 +43,10 @@ Custom attributes are allowed as props, like `lang`:
 
 The `ctx` parameter is an object containing the following keys:
 
-- `pathname`` - Current route. That is the path of the page in /pages
+- `pathname` - Current route. That is the path of the page in /pages
 - `req`: [The HTTP IncomingMessage object](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
 - `res`: [The HTTP response object](https://nodejs.org/api/http.html#http_class_http_serverresponse).
-- `err`` - Error object if any error is encountered during the rendering
+- `err` - Error object if any error is encountered during the rendering
 - `renderPage`: `Function` - a callback that runs the actual React rendering logic (synchronously). It's useful to decorate this function in order to support server-rendering wrappers for things like styled-components
 
 ## Caveats

--- a/docs/session-management.mdx
+++ b/docs/session-management.mdx
@@ -222,7 +222,7 @@ interface SessionModel extends Record<any, any> {
 }
 ```
 
-## Customize Session Persistence & Database Acess
+## Customize Session Persistence & Database Access
 
 By default, session persistence is zero-config with Prisma. However, you can customize this to save sessions somewhere else, like Redis. You can also customize this if you have Prisma but want to customize the attribute names on the user or session model.
 


### PR DESCRIPTION
There was a small spelling mistake: "Access" was spelled "Acess".