### PR TITLE
Change discord channel name in tutorial.mdx

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -729,4 +729,4 @@ export default ShowQuestionPage
 
 If you want to share your project with the world wide Blitz community there is no better place to do that than on Discord.
 
-Visit [discord.blitzjs.com](https://discord.blitzjs.com). Then, post the link to the **#show-and-tell** channel to share it with everyone!
+Visit [discord.blitzjs.com](https://discord.blitzjs.com). Then, post the link to the **#built-with-blitz** channel to share it with everyone!


### PR DESCRIPTION
I just finished [Blitz.js tutorial](https://blitzjs.com/docs/tutorial) and joined Blitz.js Discord but couldn't find the channel noted on the tutorial. (**#show-and-tell**) Guess it's recently renamed to **#built-with-blitz**? 

(Not sure if this PR is worth it since I know you guys are working on a new version doc that contains `docs/tutorial.mdx` too)