### PR TITLE
Mention supported Node.js version, and explicitly mention Node.js 15…

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -11,7 +11,7 @@ Before getting started, know **this is beta software**. You may encounter bugs o
 
 #### Set Up Your Computer
 
-You need Node.js 12 or newer
+You need Node.js 12 up to version 14. Node.js 15 is not yet supported due to peer depenencies.
 
 #### Install Blitz
 


### PR DESCRIPTION
… being unsuported.

See https://github.com/blitz-js/blitz/issues/1668 for a discussion on why Node.js 15 is currently unsupported.