### PR TITLE
Fix dateTime example on Scalar Fields

### DIFF
--- a/docs/cli-generate.mdx
+++ b/docs/cli-generate.mdx
@@ -149,7 +149,7 @@ For more details, see the [docs on Prisma scalar types](https://www.prisma.io/do
 
 ```bash
 > blitz generate model puppy isCute:boolean
-> blitz generate model rocket launchedAt:datetime
+> blitz generate model rocket launchedAt:dateTime
 > blitz generate model task completed:boolean:default[false]
 ```
 


### PR DESCRIPTION
The example for creating a model with a `dateTime` field doesn't have the capital T. If the model is created with the lowercase t, the prisma migration fails.