### PR TITLE
Typo fix on tradeoffs page

### DIFF
--- a/app/pages/docs/tradeoffs.mdx
+++ b/app/pages/docs/tradeoffs.mdx
@@ -48,7 +48,7 @@ That said, you can add a GraphQL server to your Blitz app for other clients. Thi
 
 Currently Blitz is fairly minimal on backend architecture, especially compared so something like Nest.js or AdonisJs. However, that doesn't mean you can't use those patterns in Blitz, it just means you have to set it up yourself. In fact you can use Nest.js in your Blitz app if you need.
 
-But we are very interested in brining more advanced backend architectures to Blitz by default or via easy opt-in. We have an [ongoing discussion](https://github.com/blitz-js/blitz/discussions/1841) that we'd love you to chime in on if you have ideas.
+But we are very interested in bringing more advanced backend architectures to Blitz by default or via easy opt-in. We have an [ongoing discussion](https://github.com/blitz-js/blitz/discussions/1841) that we'd love you to chime in on if you have ideas.
 
 
 ## Single Threaded When Not Deployed Serverless


### PR DESCRIPTION
Small typo on tradeoffs page I noticed when reading the docs.