### PR TITLE
Languages and Translations entry

### DIFF
--- a/app/navs/documentation.js
+++ b/app/navs/documentation.js
@@ -62,6 +62,7 @@ export const documentationNav = [
       pages["contributing"],
       pages["maintainers"],
       pages["code-of-conduct"],
+      pages["translations"],
     ],
   },
   {

--- a/app/pages/docs/translations.mdx
+++ b/app/pages/docs/translations.mdx
@@ -3,7 +3,7 @@ title: Help Us Translate Blitz.js
 sidebar_label: Translations
 ---
 
-Blitz.js is used by many people arround the world, and we want to make it easy for them to navigate the documentation and use Blitz.
+Blitz.js is used by many people arround the world, and we want them to be comfortable navigating the documentation and using Blitz.
 
 In the [languages](/languages) page, you'll see the translation progress of each language. You can click on **Contribute** and create a Pull Request with your contribution!
 

--- a/app/pages/docs/translations.mdx
+++ b/app/pages/docs/translations.mdx
@@ -1,0 +1,10 @@
+---
+title: Help Us Translate Blitz.js
+sidebar_label: Translations
+---
+
+Blitz.js is used by many people arround the world, and we want to make it easy for them to navigate the documentation and use Blitz.
+
+In the [languages](/languages) page, you'll see the translation progress of each language. You can click on **Contribute** and create a Pull Request with your contribution!
+
+If your language isn't being translated and you want to work on it, read [these instructions](https://github.com/blitz-js/blitzjs.com-translation/blob/main/README.md).

--- a/app/pages/docs/translations.mdx
+++ b/app/pages/docs/translations.mdx
@@ -1,6 +1,6 @@
 ---
-title: Help Us Translate Blitz.js
-sidebar_label: Translations
+title: Help Us Translate Blitz Docs
+sidebar_label: Doc Translations
 ---
 
 Blitz.js is used by many people arround the world, and we want them to be comfortable navigating the documentation and using Blitz.

--- a/app/pages/languages.js
+++ b/app/pages/languages.js
@@ -12,35 +12,41 @@ const LanguagesPage = ({ languages }) => {
   }, [navIsOpen])
 
   return (
-    <div className="relative py-1 md:py-3">
+    <div className="relative py-1 md:py-3 min-h-screen bg-white dark:bg-purple-deep">
       <SocialCards imageUrl="/social-homepage.png" />
-      <div className="z-30 text-white col-span-full">
-        <Header
-          className="px-6 mx-auto max-w-7xl"
-          onNavToggle={(isOpen) => {
-            setNavIsOpen(isOpen)
-          }}
-        />
-      </div>
+      <Header
+        className="px-6 mx-auto max-w-7xl"
+        hasLightBg
+        useColoredLogo
+        stickyBgClass="bg-white dark:bg-purple-deep"
+        hasFade
+        onNavToggle={(isOpen) => {
+          setNavIsOpen(isOpen)
+        }}
+      />
       <div
         className={
           "absolute w-full h-full row-start-1 row-end-5 background-to-video rounded-bl-3xl xl:rounded-bl-4xl bg-gradient-to-b from-purple-mid to-purple-primary dark:from-black dark:to-purple-off-black " +
           (navIsOpen ? "z-20 fixed" : "-z-10")
         }
       ></div>
-      <div className="mx-auto max-w-7xl px-6 py-24 xl:py-44 text-white">
-        <h1 className="font-primary text-3xl lg:text4xl xl:text-5xl font-semibold mb-16 w-full">
-          Languages
-        </h1>
+      <main className="mx-auto max-w-7xl px-6 py-24 xl:py-44 text-black dark:text-white">
+        <div className="mb-16">
+          <h1 className="font-primary text-3xl lg:text4xl xl:text-5xl font-semibold">Languages</h1>
+          <p className="font-secondary text-sm">
+            The Blitz.js documentation isn't available in any language other than English, but we
+            are working on these languages:
+          </p>
+        </div>
         <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-12 gap-y-6">
           {languages.map((lang) => (
             <div key={lang.code}>
               <h3 className="xl:mb-0 text-xl">{lang.name}</h3>
-              <p className="text-sm">
+              <p className="text-sm font-secondary">
                 {lang.completition}% —{" "}
                 <a
                   href={`https://github.com/blitz-js/${lang.code}.blitzjs.com/issues/1`}
-                  className="font-bold underline hover:text-purple-extralight"
+                  className="text-purple-light font-medium dark:font-bold no-underline dark:underline dark:hover:text-purple-extralight hover:underline"
                 >
                   Contribute
                 </a>
@@ -48,8 +54,8 @@ const LanguagesPage = ({ languages }) => {
             </div>
           ))}
         </div>
-      </div>
-      <Footer className="dark:bg-purple-off-black bg-purple-mid text-white" hasDarkMode />
+      </main>
+      <Footer className="text-black dark:text-dark-mode-text" hasDarkMode />
     </div>
   )
 }

--- a/app/pages/languages.js
+++ b/app/pages/languages.js
@@ -1,0 +1,119 @@
+import { Header } from "@/components/Header"
+import { Octokit } from "@octokit/rest"
+import { Footer } from "@/components/home/Footer"
+import { useState, useEffect } from "react"
+import { SocialCards } from "../components/SocialCards"
+
+const LanguagesPage = ({ languages }) => {
+  const [navIsOpen, setNavIsOpen] = useState(false)
+
+  useEffect(() => {
+    document.body.style.overflow = navIsOpen ? "hidden" : "unset"
+  }, [navIsOpen])
+
+  return (
+    <div className="relative py-1 md:py-3">
+      <SocialCards imageUrl="/social-homepage.png" />
+      <div className="z-30 text-white col-span-full">
+        <Header
+          className="px-6 mx-auto max-w-7xl"
+          onNavToggle={(isOpen) => {
+            setNavIsOpen(isOpen)
+          }}
+        />
+      </div>
+      <div
+        className={
+          "absolute w-full h-full row-start-1 row-end-5 background-to-video rounded-bl-3xl xl:rounded-bl-4xl bg-gradient-to-b from-purple-mid to-purple-primary dark:from-black dark:to-purple-off-black " +
+          (navIsOpen ? "z-20 fixed" : "-z-10")
+        }
+      ></div>
+      <div className="mx-auto max-w-7xl px-6 py-24 xl:py-44 text-white">
+        <h1 className="font-primary text-3xl lg:text4xl xl:text-5xl font-semibold mb-16 w-full">
+          Languages
+        </h1>
+        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-12 gap-y-6">
+          {languages.map((lang) => (
+            <div key={lang.code}>
+              <h3 className="xl:mb-0 text-xl">{lang.name}</h3>
+              <p className="text-sm">
+                {lang.completition}% —{" "}
+                <a
+                  href={`https://github.com/blitz-js/${lang.code}.blitzjs.com/issues/1`}
+                  className="font-bold underline hover:text-purple-extralight"
+                >
+                  Contribute
+                </a>
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <Footer className="dark:bg-purple-off-black bg-purple-mid text-white" hasDarkMode />
+    </div>
+  )
+}
+
+const getStaticProps = async () => {
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_AUTH_TOKEN,
+  })
+
+  const { data } = await octokit.repos.getContent({
+    owner: "blitz-js",
+    repo: "blitzjs.com-translation",
+    path: "langs",
+  })
+
+  const languages = await Promise.all(
+    data.map(async (lang) => {
+      const [{ data: langJson }, { data: langIssue }] = await Promise.all([
+        octokit.repos.getContent({
+          owner: "blitz-js",
+          repo: "blitzjs.com-translation",
+          path: lang.path,
+        }),
+        octokit.issues.get({
+          owner: "blitz-js",
+          repo: `${lang.name.substr(0, lang.name.length - 5)}.blitzjs.com`,
+          issue_number: 1,
+        }),
+      ])
+
+      const langMeta = JSON.parse(
+        Buffer.from(langJson.content, langJson.encoding).toString("utf-8")
+      )
+
+      const checkedBoxes = langIssue.body.match(/\* \[x\]/gi)
+      const totalBoxes = langIssue.body.match(/\* \[(x| )?\]/gi)
+      const completition = !totalBoxes
+        ? 100
+        : !checkedBoxes
+        ? 0
+        : Math.round((checkedBoxes.length / totalBoxes.length) * 100)
+
+      return { ...langMeta, completition, completed: false }
+    })
+  )
+
+  return {
+    props: {
+      languages: languages.sort((a, b) =>
+        a.completition === b.completition
+          ? a.name.localeCompare(b.name)
+          : a.completition > b.completition
+      ),
+    },
+    revalidate: 3 * 60 * 60, // 3 hours
+  }
+}
+
+LanguagesPage.layoutProps = {
+  meta: {
+    title: "Languages - Blitz.js",
+    description: `Blitz is a hyper-productive fullstack React framework that's built on Next.js and features a "Zero-API" data layer.`,
+  },
+}
+
+export default LanguagesPage
+export { getStaticProps }

--- a/app/pages/languages.js
+++ b/app/pages/languages.js
@@ -30,12 +30,11 @@ const LanguagesPage = ({ languages }) => {
           (navIsOpen ? "z-20 fixed" : "-z-10")
         }
       ></div>
-      <main className="mx-auto max-w-7xl px-6 py-24 xl:py-44 text-black dark:text-white">
-        <div className="mb-16">
+      <main className="mx-auto max-w-7xl px-6 py-24 xl:py-44 text-black dark:text-dark-mode-text space-y-16 lg:space-y-20">
+        <div className="space-y-6">
           <h1 className="font-primary text-3xl lg:text4xl xl:text-5xl font-semibold">Languages</h1>
-          <p className="font-secondary text-sm">
-            The Blitz.js documentation isn't available in any language other than English, but we
-            are working on these languages:
+          <p className="font-secondary text-lg text-gray-600 dark:text-gray-300">
+            The Blitz documentation is currently being translated into the following languages:
           </p>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-12 gap-y-6">
@@ -46,9 +45,9 @@ const LanguagesPage = ({ languages }) => {
                 {lang.completition}% —{" "}
                 <a
                   href={`https://github.com/blitz-js/${lang.code}.blitzjs.com/issues/1`}
-                  className="text-purple-light font-medium dark:font-bold no-underline dark:underline dark:hover:text-purple-extralight hover:underline"
+                  className="text-purple-light dark:text-purple-extralight font-medium dark:font-bold no-underline dark:underline hover:underline"
                 >
-                  Contribute
+                  Help Translate
                 </a>
               </p>
             </div>


### PR DESCRIPTION
I added a very simple languages page. It's only meant to track the progress of each translation (for now)

Also, I added a entry in the docs with a bit of information for everyone who wants to translate Blitz. It's meant to be used in this situations:

> — Hey, how can I help translating Blitz?
> — https://blitzjs.com/docs/translations