### PR TITLE
don't store updateChoiceMutation in variable

### DIFF
--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -741,7 +741,7 @@ export const Question = () => {
 +
 +  const handleVote = async (id: number) => {
 +    try {
-+      const updated = await updateChoiceMutation({ id })
++      await updateChoiceMutation({ id })
 +      refetch()
 +    } catch (error) {
 +      alert("Error updating choice " + JSON.stringify(error, null, 2))


### PR DESCRIPTION
Since the `updated` const isn't actually used, and since it's not present in the complete code block just below this one, I figured it could be removed 👍