### PR TITLE
Fix: Spelling of spawning corrected

### DIFF
--- a/app/pages/docs/tradeoffs.mdx
+++ b/app/pages/docs/tradeoffs.mdx
@@ -53,6 +53,6 @@ But we are very interested in bringing more advanced backend architectures to Bl
 
 ## Single Threaded When Not Deployed Serverless {#single-threaded-when-not-deployed-serverless}
 
-This is a tradeoff of Next.js specifically. Next.js is single threaded which means if you are doing heavy backend processing you may notice that all web requests begin to suffer. The solution to this is spawing background processing off into other processes.
+This is a tradeoff of Next.js specifically. Next.js is single threaded which means if you are doing heavy backend processing you may notice that all web requests begin to suffer. The solution to this is spawning background processing off into other processes.
 
 Running multiple background processes isn't super difficult, but we want to add docs and APIs that make this as simple as possible.


### PR DESCRIPTION
Corrected the word spawing as spawning in the "Single Threaded When Not Deployed Serverless" section.