### PR TITLE
Fix render.yaml example of deploy-render `Without database`

### DIFF
--- a/app/pages/docs/deploy-render.mdx
+++ b/app/pages/docs/deploy-render.mdx
@@ -32,11 +32,6 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
-      - key: DATABASE_URL
-        fromDatabase:
-          name: blitzapp-db
-          property: connectionString
-    startCommand: blitz start -H 0.0.0.0
 ```
 
 #### With Postgres database:


### PR DESCRIPTION
There was unwanted properties that caused the build to fail,
so I removed them.