### PR TITLE
Update test env when switching to psql

### DIFF
--- a/app/pages/docs/database-overview.mdx
+++ b/app/pages/docs/database-overview.mdx
@@ -65,7 +65,8 @@ datasource db {
 2. In `.env.local`, change `DATABASE_URL`. For convenience, there is a
    commented-out PostgreSQL `DATABASE_URL` there already. Depending on
    your setup, you may need to modify the URL.
-3. Delete the `db/migrations` folder
-4. Run `blitz prisma migrate dev --preview-feature`. This command will
+3. Update `.env.test.local` as well to use PostgreSQL for your test runs.
+4. Delete the `db/migrations` folder
+5. Run `blitz prisma migrate dev --preview-feature`. This command will
    create the database (if it does not already exist) and tables based on
    your schema.

--- a/app/pages/docs/database-overview.mdx
+++ b/app/pages/docs/database-overview.mdx
@@ -65,7 +65,7 @@ datasource db {
 2. In `.env.local`, change `DATABASE_URL`. For convenience, there is a
    commented-out PostgreSQL `DATABASE_URL` there already. Depending on
    your setup, you may need to modify the URL.
-3. Update `.env.test.local` as well to use PostgreSQL for your test runs.
+3. Update `.env.test.local` as well to use PostgreSQL in your test runs.
 4. Delete the `db/migrations` folder
 5. Run `blitz prisma migrate dev --preview-feature`. This command will
    create the database (if it does not already exist) and tables based on


### PR DESCRIPTION
I ran into an issue when trying these steps out directly: updating the database URL changes the behavior of the app, but as soon as you go to commit those changes, tests will fail because `.env.test.local` will still contain an SQLite configuration instead of Postgres.

<details>
<summary>Error log</summary>

```
➜  blitz-redo git:(main) ✗ y test
yarn run v1.22.4
$ jest
 FAIL   SERVER  app/auth/mutations/resetPassword.test.ts
  ● resetPassword mutation › works correctly

    Failed: 1

      3 | import { hash256, SecurePassword } from "blitz"
      4 |
    > 5 | beforeEach(async () => {
        | ^
      6 |   await db.$reset()
      7 | })
      8 |

      at Env.beforeEach (node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:46:24)
      at Object.<anonymous> (app/auth/mutations/resetPassword.test.ts:5:1)

  ● resetPassword mutation › works correctly


    Invalid `prisma.user.create()` invocation:


      error: Error validating datasource `db`: The URL for datasource `db` must start with the protocol `postgresql://`.
      -->  schema.prisma:6
       |
     5 |   provider = "postgres"
     6 |   url      = env("DATABASE_URL")
       |

    Validation Error Count: 1

      25 |     past.setHours(past.getHours() - 4)
      26 |
    > 27 |     const user = await db.user.create({
         |                  ^
      28 |       data: {
      29 |         email: "user@example.com",
      30 |         tokens: {

      at cb (node_modules/@prisma/client/runtime/index.js:78695:17)
      at Object.<anonymous> (app/auth/mutations/resetPassword.test.ts:27:18)

 FAIL   SERVER  app/auth/mutations/forgotPassword.test.ts
  ● forgotPassword mutation › does not throw error if user doesn't exist

    Failed: 1

      4 | import previewEmail from "preview-email"
      5 |
    > 6 | beforeEach(async () => {
        | ^
      7 |   await db.$reset()
      8 | })
      9 |

      at Env.beforeEach (node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:46:24)
      at Object.<anonymous> (app/auth/mutations/forgotPassword.test.ts:6:1)

  ● forgotPassword mutation › does not throw error if user doesn't exist

    expect(received).resolves.not.toThrow()

    Received promise rejected instead of resolved
    Rejected to value: [Error:·
    Invalid `prisma.user.findFirst()` invocation:··
      error: Error validating datasource `db`: The URL for datasource `db` must start with the protocol `postgresql://`.
      -->  schema.prisma:6
       |·
     5 |   provider = "postgres"
     6 |   url      = env("DATABASE_URL")
       |··
    Validation Error Count: 1]

      17 | describe("forgotPassword mutation", () => {
      18 |   it("does not throw error if user doesn't exist", async () => {
    > 19 |     await expect(forgotPassword({ email: "no-user@email.com" }, {} as Ctx)).resolves.not.toThrow()
         |           ^
      20 |   })
      21 |
      22 |   it("works correctly", async () => {

      at expect (node_modules/expect/build/index.js:134:15)
      at Object.<anonymous> (app/auth/mutations/forgotPassword.test.ts:19:11)

  ● forgotPassword mutation › works correctly

    Failed: 1

      4 | import previewEmail from "preview-email"
      5 |
    > 6 | beforeEach(async () => {
        | ^
      7 |   await db.$reset()
      8 | })
      9 |

      at Env.beforeEach (node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:46:24)
      at Object.<anonymous> (app/auth/mutations/forgotPassword.test.ts:6:1)

  ● forgotPassword mutation › works correctly


    Invalid `prisma.user.create()` invocation:


      error: Error validating datasource `db`: The URL for datasource `db` must start with the protocol `postgresql://`.
      -->  schema.prisma:6
       |
     5 |   provider = "postgres"
     6 |   url      = env("DATABASE_URL")
       |

    Validation Error Count: 1

      22 |   it("works correctly", async () => {
      23 |     // Create test user
    > 24 |     const user = await db.user.create({
         |                  ^
      25 |       data: {
      26 |         email: "user@example.com",
      27 |         tokens: {

      at cb (node_modules/@prisma/client/runtime/index.js:78695:17)
      at Object.<anonymous> (app/auth/mutations/forgotPassword.test.ts:24:18)


Test Suites: 2 failed, 1 skipped, 2 of 3 total
Tests:       3 failed, 1 skipped, 4 total
Snapshots:   0 total
Time:        5.313 s, estimated 6 s
Ran all test suites in 2 projects.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>