### PR TITLE
Apply code replacement for // highlight-line

### DIFF
--- a/app/core/styles/prism.css
+++ b/app/core/styles/prism.css
@@ -75,10 +75,6 @@
 }
 
 .token.comment {
-  @apply text-blue-dark;
-}
-
-.token.comment {
   @apply text-gray-600;
 }
 
@@ -108,7 +104,7 @@
 }
 
 .token.highlighted:not(.prefix) {
-  @apply block bg-purple-light bg-opacity-25 -mx-4 px-4;
+  @apply block bg-purple-light bg-opacity-25 -mx-4 px-4 -mb-4;
 }
 .token.highlighted:not(.prefix).not(:first-child) {
   margin-top: -1.5em;
@@ -124,10 +120,7 @@
   margin-top: 0rem;
   margin-bottom: -1.4em;
 }
-.token.highlighted:not(.prefix) > .comment:last-child {
-  height: 0;
-  display: block;
-  overflow: hidden;
-  margin-top: -1.4em;
-  margin-bottom: 0;
+
+.token.highlighted.highlighted-line {
+  @apply -mx-6;
 }

--- a/app/core/styles/prism.css
+++ b/app/core/styles/prism.css
@@ -96,7 +96,7 @@
 }
 
 .token.inserted:not(.prefix) {
-  @apply block bg-green-600 bg-opacity-25 -mx-4 px-4;
+  @apply block bg-green-600 bg-opacity-25 -ml-2 -mb-4;
 }
 
 .token.inserted.prefix {

--- a/remark/utils.js
+++ b/remark/utils.js
@@ -118,7 +118,6 @@ module.exports.highlightCode = function highlightCode(code, prismLanguage) {
   code = code
     .replace(/[^\S\r\n]*(?=\/\/ highlight-start)/g, "")
     .replace(/[^\S\r\n]*(?=\/\/ highlight-end)/g, "")
-    .replace(/.*\/\/ highlight-line$/gm, (text) => `highlightlinestart ${text} highlightlineend`)
   let highlighted = Prism.highlight(code, grammar, prismLanguage)
 
   return highlighted
@@ -129,10 +128,8 @@ module.exports.highlightCode = function highlightCode(code, prismLanguage) {
     .replace(/\w*\/\/ ?highlight-start\w*/g, "")
     .replace(/\w*\/\/ ?highlight-end\w*/g, "")
     .replace(
-      /(highlightlinestart )[\S\s]*?( highlightlineend)/g,
-      (text) => `<div class="token highlighted highlighted-line">${text}</div>`,
+      /^.*\/\/ ?highlight-line.*$/gm,
+      (text) => `<div class="token highlighted">${text}</div>`,
     )
-    .replace(/highlightlinestart/g, "")
-    .replace(/highlightlineend/g, "")
-    .replace(/\/\/ highlight-line/g, "")
+    .replace(/<span class="token comment">\/\/ ?highlight-line<\/span>/g, "")
 }

--- a/remark/utils.js
+++ b/remark/utils.js
@@ -115,10 +115,10 @@ module.exports.highlightCode = function highlightCode(code, prismLanguage) {
     console.warn(`Unrecognised language: ${prismLanguage}`)
     return Prism.util.encode(code)
   }
-  code = code.replace(
-    /.*\/\/ highlight-line$/gm,
-    (text) => `highlightlinestart ${text} highlightlineend`,
-  )
+  code = code
+    .replace(/[^\S\r\n]*(?=\/\/ highlight-start)/g, "")
+    .replace(/[^\S\r\n]*(?=\/\/ highlight-end)/g, "")
+    .replace(/.*\/\/ highlight-line$/gm, (text) => `highlightlinestart ${text} highlightlineend`)
   let highlighted = Prism.highlight(code, grammar, prismLanguage)
 
   return highlighted
@@ -127,10 +127,10 @@ module.exports.highlightCode = function highlightCode(code, prismLanguage) {
       (text) => `<div class="token highlighted">${text}</div>`,
     )
     .replace(/\w*\/\/ ?highlight-start\w*/g, "")
-    .replace(/\w*\/\/ ?highlight-end\w*/gm, "")
+    .replace(/\w*\/\/ ?highlight-end\w*/g, "")
     .replace(
       /(highlightlinestart )[\S\s]*?( highlightlineend)/g,
-      (text) => `<div class="token inserted">${text}</div>`,
+      (text) => `<div class="token highlighted highlighted-line">${text}</div>`,
     )
     .replace(/highlightlinestart/g, "")
     .replace(/highlightlineend/g, "")

--- a/remark/utils.js
+++ b/remark/utils.js
@@ -115,13 +115,24 @@ module.exports.highlightCode = function highlightCode(code, prismLanguage) {
     console.warn(`Unrecognised language: ${prismLanguage}`)
     return Prism.util.encode(code)
   }
+  code = code.replace(
+    /.*\/\/ highlight-line$/gm,
+    (text) => `highlightlinestart ${text} highlightlineend`,
+  )
   let highlighted = Prism.highlight(code, grammar, prismLanguage)
 
   return highlighted
     .replace(
       /(<span(?:(?!<span)[\s\S])*(\/\/ ?highlight-start))[\S\s]*?((\/\/ ?highlight-end)[\S\s]*?(>))/g,
-      (text, position) => `<div class="token highlighted">${text}</div>`,
+      (text) => `<div class="token highlighted">${text}</div>`,
     )
     .replace(/\w*\/\/ ?highlight-start\w*/g, "")
-    .replace(/\w*\/\/ ?highlight-end\w*/g, "")
+    .replace(/\w*\/\/ ?highlight-end\w*/gm, "")
+    .replace(
+      /(highlightlinestart )[\S\s]*?( highlightlineend)/g,
+      (text) => `<div class="token inserted">${text}</div>`,
+    )
+    .replace(/highlightlinestart/g, "")
+    .replace(/highlightlineend/g, "")
+    .replace(/\/\/ highlight-line/g, "")
 }


### PR DESCRIPTION
Fixes #410 

This is an ugly hack, I must apologise. What we should do next is to find a different way to write the `// highlight-line`, `// highlight-start` and `// highlight-end` for syntax highlighting if we want to go about doing this better. 