### PR TITLE
Optional chore: Add and use @tailwindcss/jit

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@mdx-js/loader": "^1.6.22",
     "@next/bundle-analyzer": "^10.0.8",
     "@svgr/webpack": "^5.4.0",
+    "@tailwindcss/jit": "0.1.3",
     "@tailwindcss/typography": "0.4.0",
     "alex": "9.1.0",
     "autoprefixer": "^10.2.5",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: ["tailwindcss", "postcss-nested", "autoprefixer"],
+  plugins: ["@tailwindcss/jit", "postcss-nested", "autoprefixer"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,6 +2717,19 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tailwindcss/jit@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/jit/-/jit-0.1.3.tgz#50390d9ac95fee78ed23a7e2320ef20bd4a35354"
+  integrity sha512-7VAvHKNLJxbGWRKxo2Z+beiodag7vWPx8b/+Egd5fve4zFihsngeNt6RwQFnll+almjppRYefRC5Py5v5K+6vg==
+  dependencies:
+    chokidar "^3.5.1"
+    dlv "^1.1.3"
+    fast-glob "^3.2.5"
+    lodash.topath "^4.5.2"
+    object-hash "^2.1.1"
+    postcss-selector-parser "^6.0.4"
+    quick-lru "^5.1.1"
+
 "@tailwindcss/typography@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.4.0.tgz#b80974ad6af93df7b06e1981cb4d79698b6ad5c7"
@@ -4456,7 +4469,7 @@ checkpoint-client@1.1.18:
     node-fetch "2.6.1"
     uuid "8.3.0"
 
-chokidar@3.5.1:
+chokidar@3.5.1, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -6266,7 +6279,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@3.2.5:
+fast-glob@3.2.5, fast-glob@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -9138,6 +9151,11 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
+lodash.topath@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
+  integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
 
 lodash.union@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
Tailwind just released a spanking new experimental library for just-in-time compilations a few days ago: https://blog.tailwindcss.com/just-in-time-the-next-generation-of-tailwind-css

For me who's using an underpowered laptop, developing on blitzjs.com was quite a pain as any change I made would trigger a CSS recompilation and my browser would struggle to apply the large css bundle as we enabled quite a few variants (perhaps we don't even use all the enabled variants, but since V2 was a fork off the tailwind website.. we didn't look into removing the unused variants)

While the library is experimental, I think it is sufficiently ready and will bring a lot of benefits by this simple small change. But of course, this is optional and we don't have to apply it if we don't want to :)