### PR TITLE
render.yaml fix to properly deploy to Render

### DIFF
--- a/app/pages/docs/deploy-render.mdx
+++ b/app/pages/docs/deploy-render.mdx
@@ -32,6 +32,8 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      - key: SESSION_SECRET_KEY
+        generateValue: true
 ```
 
 #### With Postgres database:
@@ -58,6 +60,8 @@ services:
         fromDatabase:
           name: blitzapp-db
           property: connectionString
+      - key: SESSION_SECRET_KEY
+        generateValue: true
 
 databases:
   - name: blitzapp-db


### PR DESCRIPTION
When following the above example to deploy to render I received an error that I needed to pass the SESSION_SECRET_KEY. In this change I leverage Render's IaC capability to generate this secret at runtime so new users can quickly deploy without errors.