### PR TITLE
Remove redundant steps from `deploy-render.mdx`

### DIFF
--- a/app/pages/docs/deploy-render.mdx
+++ b/app/pages/docs/deploy-render.mdx
@@ -9,12 +9,7 @@ sidebar_label: To Render.com
 4. Click on the "YAML" menu item, then click the "New from YAML" button
 5. Connect your GitHub account then select your blitz app repo
 6. Click approve
-7. Go to "Services", click on your new Blitz service, click on
-   "Environment"
-8. Click "Add Environment Variable", enter `SESSION_SECRET_KEY` as the
-   name, then click on the "generate" button in the value field. Then
-   click save.
-9. Your server + database will be automatically configured and started.
+7. Your server + database will be automatically configured and started.
    Each git push will trigger a new deploy
 
 #### Without database:


### PR DESCRIPTION
I just deployed my blitz app to render.com and while I had been following official instructions I had noticed that two steps can be removed.

#421 introduced automatic `SESSION_SECRET_KEY` environment variable creation which makes steps about adding it manually not necessary anymore.

