### PR TITLE
Allow emphasised text to maintain color in dark-mode

### DIFF
--- a/app/core/styles/utilities.css
+++ b/app/core/styles/utilities.css
@@ -181,6 +181,10 @@ body.cursor-grabbing * {
   @apply text-black;
 }
 
+.dark .admonition .admonition-content.admonition-content strong {
+  color: inherit;
+}
+
 .topic-select .topic-select__placeholder,
 .topic-select .topic-select__menu-list,
 .topic-select .topic-select__single-value {


### PR DESCRIPTION
This is an attempt to make a minimal change fix for the issue raised https://github.com/blitz-js/blitzjs.com/issues/431

This change makes sure the use of `<strong>` tags does not override the section's color. The text remains bold so I believe it's still differentiated enough.

I wouldn't be surprised if you'd like to go in a different direction with this change, perhaps adjusting the yellow or implementing a solution that would cover other tags. But wanted to start with suggesting the smallest fix I could find.

**Implementation note:** I was unable to use a CSS Tailwind class as I do not believe they support `color: inherit` (See Github Discussion https://github.com/tailwindlabs/tailwindcss/discussions/1361). I've used the direct CSS instead.

**Current**
![RFC Specification Caution with White text on Yellow](https://user-images.githubusercontent.com/13903378/113875127-cb655a00-97f9-11eb-9800-d82080a71399.png)

**With change**
![RFC Specification Caution with Black text on Yellow](https://user-images.githubusercontent.com/13903378/113875149-d15b3b00-97f9-11eb-9e2f-7f4e843cbf9b.png)

closes: https://github.com/blitz-js/blitzjs.com/issues/431

**Update:** I should have mentioned I've tested this change with the other locations that use :::caution

- https://blitzjs.com/docs/cli-db
- https://blitzjs.com/docs/deploy-vercel
- https://blitzjs.com/docs/image-optimization

Two are unaffected and one sees the same improvement as above:

**With change:** hurt performance is now visible
![Image Optimisation Caution with Black text on Yellow](https://user-images.githubusercontent.com/13903378/113876590-395e5100-97fb-11eb-9aa2-966e6a283703.png)
