### PR TITLE
Error in tutorial

### DIFF
--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -274,6 +274,7 @@ pages for the `Choice` model:
 ```sh
 blitz generate resource choice text votes:int:default=0 belongsTo:question
 ```
+If you get an error run `blitz prisma format`
 
 Again, hit **Enter** when prompted to run the migration and enter a name
 for the migration.


### PR DESCRIPTION
I got an error from running:
```sh
blitz generate resource choice text votes:int:default=0 belongsTo:question
```
the fix:
 `blitz prisma format