### PR TITLE
Added `--inspect` flag to blitz start and blitz dev

### DIFF
--- a/app/pages/docs/cli-dev.mdx
+++ b/app/pages/docs/cli-dev.mdx
@@ -14,6 +14,7 @@ Starts the Blitz development server.
 | `--hostname`             | `-H`      | Set the hostname to use for the server.                | `"localhost"` |
 | `--port`                 | `-p`      | Set the port you'd like the server to listen on.       | `3000`        |
 | `--no-incremental-build` |           | Disable incremental build and start from a fresh cache | `false`       |
+| `--inspect`              |           | Enable the Node.js inspector                           | `false`       |
 
 #### Examples
 

--- a/app/pages/docs/cli-start.mdx
+++ b/app/pages/docs/cli-start.mdx
@@ -13,6 +13,7 @@ Starts the Blitz production server.
 | ------------ | --------- | ------------------------------------------------ | ------------- |
 | `--hostname` | `-H`      | Set the hostname to use for the server.          | `"localhost"` |
 | `--port`     | `-p`      | Set the port you'd like the server to listen on. | `3000`        |
+| `--inspect`  |           | Enable the Node.js inspector                     | `false`       |
 
 #### Examples
 


### PR DESCRIPTION
Hey,

I added the `--inspect` flag to the documentation of `blitz start` and `blitz dev` (see https://github.com/blitz-js/blitz/pull/1063)

antony :)