### PR TITLE
Recommend customTsParser for building a new recipe

### DIFF
--- a/app/pages/docs/writing-recipes.mdx
+++ b/app/pages/docs/writing-recipes.mdx
@@ -187,11 +187,15 @@ testing, the tests are quick to write:
 
 ```typescript
 import j from "jscodeshift"
+import { customTsParser } from "@blitzjs/installer";
+
 
 const sampleFile = `export default function Comp() {
   return <div>hello!</div>;
 })`
-expect(addImport(j(sampleFile), newImport).toSource()).toMatchSnapshot()
+expect(addImport(j(sampleFile, {
+  parser: customTsParser
+}), newImport).toSource()).toMatchSnapshot()
 ```
 
 #### Modifying Non-JS files


### PR DESCRIPTION
This recommendation for writing a new recipe could be improved: the docs say that you can/should use a direct import of jscodeshift. You can do this, but it'll fail pretty soon: what a recipe really provides is a program parsed with the customTsParser, not a program parsed with the default parser.