### PR TITLE
Extend "run postgres via docker" section

### DIFF
--- a/app/pages/docs/postgres.mdx
+++ b/app/pages/docs/postgres.mdx
@@ -68,7 +68,8 @@ POSTGRES_PASSWORD=your_password
 POSTGRES_DB=your_database_name
 ```
 
-Given these values your `DATABASE_URL` should look like this
+Given these values, update `DATABASE_URL` in `.env.local` to something
+similar like
 `postgresql://your_user:your_password@localhost:5432/your_database_name`
 
 3. Modify your `package.json` to start the database before Blitz
@@ -80,5 +81,6 @@ Given these values your `DATABASE_URL` should look like this
 }
 ```
 
-4. Run `blitz prisma migrate dev` to get your new database to the latest
-   version of your migrations
+4. Start your new database and get it to the latest version of your
+   migrations by running `docker-compose up -d` and
+   `blitz prisma migrate dev`

--- a/app/pages/docs/postgres.mdx
+++ b/app/pages/docs/postgres.mdx
@@ -83,4 +83,4 @@ similar like
 
 4. Start your new database and get it to the latest version of your
    migrations by running `docker-compose up -d` and
-   `blitz prisma migrate dev`
+   `blitz prisma migrate dev`.


### PR DESCRIPTION
Hey,

more small changes: 
I've added some information about the location of `DATABASE_URL` and that the user has to run `docker-compose` before `blitz prisma migrate `.