### PR TITLE
Add `scroll-behavior: smooth;` to main.css

### DIFF
--- a/app/core/styles/main.css
+++ b/app/core/styles/main.css
@@ -11,6 +11,7 @@
 
 html {
   font-family: "Libre Franklin", sans-serif;
+  scroll-behavior: smooth;
 }
 
 .player-wrapper {


### PR DESCRIPTION
This pr is rather simple. It simply makes the scrolling when you scroll to another part of a page using an id button much smoother. For example, when you use the "Back to top" button in the footer, it won't jump up so quickly, it'll instead scroll. This is useful because it will surprise people less and it'll seem cleaner and less choppy too.