### PR TITLE
Typo in tradeoffs.mdx

### DIFF
--- a/app/pages/docs/tradeoffs.mdx
+++ b/app/pages/docs/tradeoffs.mdx
@@ -69,7 +69,7 @@ clients. This can be an excellent choice and some folks are doing this.
 ## Advanced Backend Architecture {#advanced-backend-architecture}
 
 Currently Blitz is fairly minimal on backend architecture, especially
-compared so something like Nest.js or AdonisJs. However, that doesn't mean
+compared to something like Nest.js or AdonisJs. However, that doesn't mean
 you can't use those patterns in Blitz, it means you have to set it up
 yourself. In fact you can use Nest.js in your Blitz app if you need.
 


### PR DESCRIPTION
In the second to bottom section, (Advanced Backend Architecture), it reads '...especially compared *so* something....' Word fix to *to*