### PR TITLE
Avoid hardcoding "admin" role during impersonation

### DIFF
--- a/app/pages/docs/impersonation.mdx
+++ b/app/pages/docs/impersonation.mdx
@@ -53,7 +53,7 @@ export default resolver.pipe(
 
     await ctx.session.$create({
       userId: user.id,
-      role: "admin",
+      role: user.role,
       orgId: user.organizationId,
       impersonatingFromUserId: ctx.session.userId,
     })


### PR DESCRIPTION
When you impersonate another use it would be a good idea to assumer their role too.

Most endpoints will be protected with some kind of authorizer e.g. `resolver.authorize("seller")` or `resolver.authorize("buyer")`. 
If you try and invoke these endpoints as an admin, they all need to be changed to `resolver.authorize(["seller", "admin"])` or `resolver.authorize(["buyer", "admin"])` etc.

If you assume the role of the user you're impersonating, you don't need to change anything.

In terms of security: 
- `startImpersonating` should only be available to admins, so it should be secured with `resolver.authorize("admin")`.
- we can allow `stopImpersonating` to be called without a role restriction as it is: the code already checks if `impersonatingFromUserId` is present in the session. If present, the user simply regains whatever role they had before ("admin", "support", etc), otherwise the endpoint is no-op.