### PR TITLE
Light/Dark mode fix

### DIFF
--- a/app/pages/_app.js
+++ b/app/pages/_app.js
@@ -71,7 +71,7 @@ export default function App({Component, pageProps, router}) {
         <meta key="og:type" property="og:type" content="article" />
         <meta key="og:description" property="og:description" content={meta.description} />
       </Head>
-      <ThemeProvider defaultTheme="dark" attribute="class">
+      <ThemeProvider defaultTheme="dark" enableSystem={false} attribute="class">
         <Component {...pageProps} />
       </ThemeProvider>
     </>


### PR DESCRIPTION
Hello Blitz team, 
fix of #437 
I assume that dark mode is used by default, and light mode after switching.
Tested on chrome, firefox, and safari.
