### PR TITLE
fix(multitenancy.mdx): role should be on user not organization

### DIFF
--- a/app/pages/docs/multitenancy.mdx
+++ b/app/pages/docs/multitenancy.mdx
@@ -33,7 +33,6 @@ The prisma schema looks like this:
 model Organization {
   id         Int @id @default(autoincrement())
   name       String
-  role       GlobalRole
 
   membership Membership[]
 }
@@ -71,6 +70,7 @@ model User {
   id             Int      @id @default(autoincrement())
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+  role           GlobalRole
   name           String?
   email          String   @unique
 


### PR DESCRIPTION
I was reading through the multitenancy docs and I'm pretty sure the example schema definition has the global role defined in the wrong place.  Seems like it belongs on the User and not the Organization to be consistent with the rest of the doc.  It also makes more sense to me that the User and their Membership have roles and not the Organization itself.

Only other nit is I prefer to call "GlobalRole" "UserRole" since it's on the user and then you end up with User and Member roles.  Thoughts?