### PR TITLE
Test database notes

### DIFF
--- a/app/pages/docs/database-overview.mdx
+++ b/app/pages/docs/database-overview.mdx
@@ -66,6 +66,7 @@ datasource db {
    commented-out PostgreSQL `DATABASE_URL` there already. Depending on
    your setup, you may need to modify the URL.
 3. Update `.env.test.local` as well to use PostgreSQL in your test runs.
+   (It has to point to different database than your `.env.local`)
 4. Delete the `db/migrations` folder
 5. Run `blitz prisma migrate dev`. This command will create the database
    (if it does not already exist) and tables based on your schema.

--- a/app/pages/docs/postgres.mdx
+++ b/app/pages/docs/postgres.mdx
@@ -55,6 +55,12 @@ services:
     ports:
       - "5432:5432"
 
+  db-test:
+    image: postgres:latest
+    env_file: ./.env.test.local
+    ports:
+      - 5433:5432
+
 volumes:
   data:
 ```
@@ -71,6 +77,10 @@ POSTGRES_DB=your_database_name
 Given these values, update `DATABASE_URL` in `.env.local` to something
 similar like
 `postgresql://your_user:your_password@localhost:5432/your_database_name`
+and in `.env.test.local` to
+`postgresql://your_user:your_password@localhost:5433/your_database_name`
+
+Please note that test database is using port `5433` instead of `5432`
 
 3. Modify your `package.json` to start the database before Blitz
 


### PR DESCRIPTION
- small improvements to docs (as discussed on discord) clarifying that test database must be different than main one.
- extension to `docker-compose.yml` containing pre-set test database - it has no volume on purpose as it's not something we need on test database