### PR TITLE
docs: document new setPublicDataForUser API

### DIFF
--- a/app/core/components/Header.js
+++ b/app/core/components/Header.js
@@ -80,7 +80,7 @@ const Header = ({
     onNavToggle(newValue)
   }
 
-  const bannerMsg = "Blitz is in beta! 🎉 1.0 expected in May or June"
+  const bannerMsg = "Blitz is in beta! 🎉 1.0 expected in Q3 this year"
 
   const menuLinks = [
     {

--- a/app/pages/docs/auth-utils.mdx
+++ b/app/pages/docs/auth-utils.mdx
@@ -208,3 +208,28 @@ export const authenticateUser = async (
   return rest
 }
 ```
+
+## `setPublicDataForUser()` {#setPublicDataForUser}
+
+#### `setPublicDataForUser(userId: PublicData['userId'], publicData: Record<any, any>) => void`
+
+This can be used to update the `publicData` of a user's sessions. It can
+be useful when changing a user's role, since the new permissions can be
+enforced as soon as the user is doing the next request.
+
+#### Example Usage
+
+```ts
+import { setPublicDataForUser } from "blitz"
+import db from "db"
+
+export const updateUserRole = async (
+  userId: PublicData["userId"],
+  role: string
+) => {
+  // update the user's role
+  await db.user.update({ where: { id: userId }, data: { role } })
+  // update role in all active sessions
+  await setPublicDataForUser(userId, { role })
+}
+```

--- a/app/pages/docs/auth-utils.mdx
+++ b/app/pages/docs/auth-utils.mdx
@@ -209,7 +209,7 @@ export const authenticateUser = async (
 }
 ```
 
-## `setPublicDataForUser()` {#setPublicDataForUser}
+## `setPublicDataForUser()` {#set-public-data-for-user}
 
 #### `setPublicDataForUser(userId: PublicData['userId'], publicData: Record<any, any>) => void`
 


### PR DESCRIPTION
https://github.com/blitz-js/blitz/pull/2473Cheers,

this PR adds documentation for the `setPublicDataForUser` (naming pending) API.
The API can be used to update session data for other user's to reflect permission/role changes directly, without the need to sign out and in again.

Feature PR: https://github.com/blitz-js/blitz/pull/2473