### PR TITLE
Clarify distinction between useSession & useCurrentUser

### DIFF
--- a/app/pages/docs/authorization.mdx
+++ b/app/pages/docs/authorization.mdx
@@ -221,11 +221,6 @@ This is available on the client without making a network call to the
 backend, so it's available faster than the `useCurrentUser()` approach
 described below.
 
-However, due to the nature of static pre-rendering, the `session` will not
-exist on the very first render on the client. This causes a quick "flash"
-on first load. You can fix that by setting
-[`Page.suppressFirstRenderFlicker = true`](./pages##automatic-static-optimization)
-
 ```tsx
 import { useSession } from "blitz"
 
@@ -240,8 +235,8 @@ if (session.role === "admin") {
 
 #### `useCurrentUser()`
 
-New Blitz apps by default have a `useCurrentUser()` hook and a
-corresponding `getCurrentUser` query.
+The second way is to use the `useCurrentUser()` hook. New Blitz apps by default have a `useCurrentUser()` hook and a
+corresponding `getCurrentUser` query. Unlike the `useSession()` approach above, `useCurrentUser()` will require a network call and thus be slower. If possible, you should prefer the `useSession()` approach. 
 
 ```tsx
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"

--- a/app/pages/docs/authorization.mdx
+++ b/app/pages/docs/authorization.mdx
@@ -221,6 +221,11 @@ This is available on the client without making a network call to the
 backend, so it's available faster than the `useCurrentUser()` approach
 described below.
 
+Note: due to the nature of static pre-rendering, the `session` will not
+exist on the very first render on the client. This causes a quick "flash"
+on first load. You can fix that by setting
+[`Page.suppressFirstRenderFlicker = true`](./pages##automatic-static-optimization)
+
 ```tsx
 import { useSession } from "blitz"
 
@@ -236,7 +241,7 @@ if (session.role === "admin") {
 #### `useCurrentUser()`
 
 The second way is to use the `useCurrentUser()` hook. New Blitz apps by default have a `useCurrentUser()` hook and a
-corresponding `getCurrentUser` query. Unlike the `useSession()` approach above, `useCurrentUser()` will require a network call and thus be slower. If possible, you should prefer the `useSession()` approach. 
+corresponding `getCurrentUser` query. Unlike the `useSession()` approach above, `useCurrentUser()` will require a network call and thus be slower. However, if you need access to user data that would be insecure to store in the session's `publicData`, you would need to use `useCurrentUser()` instead of `useSession()`.
 
 ```tsx
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"


### PR DESCRIPTION
Rereading through the docs it's unclear what the use-case difference is between `useSession()` and `useCurrentUser()`.

This removes the mentioning of suppressing the first render since it's unrelated to the useSession vs useCurrentUser discussion. 

I still think we need a *reason* that you would use useCurrentUser. I'm not really sure what that would be though?