### PR TITLE
Add instruction for render.yaml

### DIFF
--- a/app/pages/docs/deploy-render.mdx
+++ b/app/pages/docs/deploy-render.mdx
@@ -45,6 +45,7 @@ services:
     plan: starter
     buildCommand:
       yarn --frozen-lockfile --prod=false &&
+      blitz prisma generate &&
       blitz build &&
       blitz prisma migrate deploy
     startCommand: blitz start


### PR DESCRIPTION
When working with TypeScript the build fails when we are not creating the model first. I can add a comment if you want mentioning that the models should be generated before the build first.

Here is an error from my recent project: ![Build error without generating models](https://i.imgur.com/1PaWqyx.png)