### PR TITLE
Adds builder.printMessage documentation

### DIFF
--- a/app/pages/docs/writing-recipes.mdx
+++ b/app/pages/docs/writing-recipes.mdx
@@ -222,8 +222,8 @@ This step would append "Paul Plain was here!" to the user's README.md
 
 #### Creating a custom message
 
-Sometimes you just need to print a simple message, or give some
-instructions, you can achieve that with `printMessage`
+Sometimes you need to print a simple message, or give some instructions,
+you can achieve that with `printMessage`
 
 ```ts
 builder.printMessage({

--- a/app/pages/docs/writing-recipes.mdx
+++ b/app/pages/docs/writing-recipes.mdx
@@ -220,6 +220,36 @@ builder
 
 This step would append "Paul Plain was here!" to the user's README.md
 
+#### Creating a custom message
+
+Sometimes you just need to print a simple message, or give some
+instructions, you can achieve that with `printMessage`
+
+```ts
+builder.printMessage({
+  successIcon: "ℹ️",
+  stepId: "oops",
+  stepName: "Contributors needed!",
+  message: "If you like this recipe, consider helping out!",
+})
+```
+
+This step would print "If you like this recipe, consider helping out!" to
+terminal and wait for the user to go to the next step.
+
+#### Custom step icons
+
+If you want to customize your recipe even further, you can pass an
+optional `successIcon` param to your steps.
+
+```ts
+builder
+  .addTransformFilesStep({
+     successIcon: "🔧",
+     ...
+   })
+```
+
 #### Modifying Prisma schemas
 
 A lot of recipes may need to add or modify models in the schema.prisma


### PR DESCRIPTION
This is a feature nobody asked for (maybe?) but it's something that I think was missing in the recipes; writing a custom message step while installing a recipe. 
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: ?

### What are the changes and their implications?


Adds new step type `printMessage`

```typescript
  builder.printMessage({
    successIcon: "😭",
    stepId: "oops",
    stepName: "Im so sorry :(",
    message:
      "This recipe can't edit your blitz.config.ts (yet), you can add the Blitz Guard middleware following these two steps: https://ntgussoni.github.io/blitz-guard/docs/middleware",
  })
```

This prints the message in the following way
![image](https://user-images.githubusercontent.com/10161067/122650804-2807be00-d135-11eb-881c-aaccc97c51e6.png)
![image](https://user-images.githubusercontent.com/10161067/122650824-3eae1500-d135-11eb-9bde-405fc464ca5e.png)