### PR TITLE
Add info to set PORT for railway deployment

### DIFF
--- a/app/pages/docs/deploy-railway.mdx
+++ b/app/pages/docs/deploy-railway.mdx
@@ -57,10 +57,16 @@ The project ID is taken from the **Project Setup** page.
 
 4. Enter your required environment variables
 
-Blitz requires the `SESSION_SECRET_KEY` variable to be set. Go to your
-project on the GUI, select the Variables link and enter
-`SESSION_SECRET_KEY` as the name of the variables a random 32-key secret
-as its value. Click **Add** to add the variable.
+Set the `SESSION_SECRET_KEY` variable to a random string of 32 characters
+and the `PORT` variable to `3000`:
+
+```
+railway variables set SESSION_SECRET_KEY=<your_key>
+railway variables set PORT=3000
+```
+
+Instead of setting the `PORT` here, you could also modify the `start`
+script in the `package.json` file to `blitz start --port ${PORT-3000}`.
 
 Enter other environment variables that you require. The `DATABASE_URL`
 variable will be automatically set by Railway if you provision a
@@ -103,6 +109,8 @@ Blitz requires the `SESSION_SECRET_KEY` variable to be set. Go to your
 project on the GUI, select the **Variables** link and enter
 `SESSION_SECRET_KEY` as the name of the variable and a random 32-key
 secret as its value. Click **Add** to add the variable.
+
+Set a variable `PORT` to `3000`.
 
 Enter other environment variables that you require. The `DATABASE_URL`
 variable will be automatically set by Railway if you provision a database.


### PR DESCRIPTION
I'm just getting started with Blitz. Following the Getting Started Guide and the section about deployment on Railway I ran into an HTTP 502 Bad Gateway error.

I figured out that the port the Blitz server is running on must be configured manually for Railway. One way is to modify the start script as already [described in a discussion](https://github.com/blitz-js/blitz/discussions/2335). Another way is to add a `PORT` variable to the railway environment.

Maybe it would be a good idea to add this piece of information to the Railway Deployment section?