### PR TITLE
Update contributing doc - sync your fork section

### DIFF
--- a/app/pages/docs/contributing.mdx
+++ b/app/pages/docs/contributing.mdx
@@ -223,7 +223,6 @@ page explaining how to set it up!
 #### Sync your fork
 
 ```sh
-git remote add upstream git@github.com:blitz-js/blitz.git
 ./scripts/fetchRemote.sh
 git merge upstream/canary
 ```


### PR DESCRIPTION
Removed the git command to add `upstream` from the "Sync your fork" section in Contributing doc since the `fetchRemote` script itself checks & adds `upstream` if required.

Link to the script for quick reference - 
https://github.com/blitz-js/blitz/blob/6adf7c02d4b7c9d3fd713e3f4f2bfd300e78830d/scripts/fetchRemote.sh

Also, would it make sense to add `git merge upstream/canary` also to the script and just let people run `./scripts/fetchRemote.sh` script to update their fork? If we're happy with that, I'll make that change and also update this PR to reflect that.