### PR TITLE
Update `signup` mutation in multitenancy.mdx

### DIFF
--- a/app/pages/docs/multitenancy.mdx
+++ b/app/pages/docs/multitenancy.mdx
@@ -97,6 +97,7 @@ const user = await db.user.create({
       },
     },
   },
+  include: { memberships: true },
 })
 ```
 


### PR DESCRIPTION
Fix the `signup` mutation to make the user insertion return a user's memberships.

See https://discord.com/channels/802917734999523368/872490237719371826/872490241469083688