### PR TITLE
Fix: dead link in session management docs

### DIFF
--- a/app/pages/docs/session-management.mdx
+++ b/app/pages/docs/session-management.mdx
@@ -338,7 +338,7 @@ defined above in `SessionConfig`. The functions can do anything, but they
 must conform to the defined input and outputs types.
 
 For reference, here's
-[the default config that works with Prisma](https://github.com/blitz-js/blitz/blob/canary/packages/core/src/server/auth/sessions.ts#L65-L88).
+[the default config that works with Prisma](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/stdlib-server/auth-sessions.ts#L74).
 
 ## Manual API Requests {#manual-api-requests}
 


### PR DESCRIPTION
Resolves: #540 

Fixed dead link in 'Customize Session Persistence & Database Access' section of the session management docs. Replaced the dead link with the current default implementation of `SessionConfig`.