### PR TITLE
Fix: clarify the single-threading tradeoff (#514)

### DIFF
--- a/app/pages/docs/tradeoffs.mdx
+++ b/app/pages/docs/tradeoffs.mdx
@@ -78,12 +78,17 @@ to Blitz by default or via simple opt-in. We have an
 [ongoing discussion](https://github.com/blitz-js/blitz/discussions/1841)
 that we'd love you to chime in on if you have ideas.
 
-## Single Threaded When Not Deployed Serverless {#single-threaded-when-not-deployed-serverless}
+## Single Threaded {#single-threaded}
 
-This is a tradeoff of Next.js specifically. Next.js is single threaded
+This is a tradeoff of Node.js in general. Node.js is single threaded
 which means if you are doing heavy backend processing you may notice that
 all web requests begin to suffer. The solution to this is spawning
 background processing off into other processes.
 
 Running multiple background processes isn't super difficult, but we want
 to add docs and APIs that make this as simple as possible.
+
+This isn't a problem when deployed to some serverless platforms, such as
+Vercel, because these platforms only allow a given Node.js process
+to serve one request at a time anyway. However, note that [deployment
+to Vercel is not recommended for other reasons](./deploy-vercel.mdx).

--- a/app/pages/docs/tradeoffs.mdx
+++ b/app/pages/docs/tradeoffs.mdx
@@ -91,4 +91,4 @@ to add docs and APIs that make this as simple as possible.
 This isn't a problem when deployed to some serverless platforms, such as
 Vercel, because these platforms only allow a given Node.js process
 to serve one request at a time anyway. However, note that [deployment
-to Vercel is not recommended for other reasons](./deploy-vercel.mdx).
+to Vercel is not recommended for other reasons](./deploy-vercel).


### PR DESCRIPTION
I identified this tradeoff as belonging to Node.js generally rather than Next.js specifically. I also removed the bit about serverless from the heading, as it implied (at least to me) that the serverless deployment was somehow multithreaded. Instead, I added another paragraph explaining why this tradeoff is irrelevant on at least some serverless platforms, while noting that deployment to Vercel specifically is not recommended.