### PR TITLE
Custom server example handles some routes twice resulting in an error

### DIFF
--- a/app/pages/docs/custom-server.mdx
+++ b/app/pages/docs/custom-server.mdx
@@ -45,12 +45,12 @@ app.prepare().then(() => {
     if (pathname === "/hello") {
       res.writeHead(200).end("world")
       return
-    } else if (pathname === "/a") {
+    }
+    
+    if (pathname === "/a") {
+      // renders app/pages/a.tsx
       app.render(req, res, "/a", query)
-    } else if (pathname === "/b") {
-      app.render(req, res, "/b", query)
-    } else {
-      handle(req, res, parsedUrl)
+      return
     }
 
     handle(req, res, parsedUrl)


### PR DESCRIPTION
Custom server handles some routes twice, resulting in an error: `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`
Reproducible for any not pre-defined route, e.g. `/abc`