### PR TITLE
add docs on client vs server

### DIFF
--- a/app/core/navs/documentation.json
+++ b/app/core/navs/documentation.json
@@ -49,7 +49,8 @@
       "error-handling",
       "error-boundary",
       "testing",
-      "utilities"
+      "utilities",
+      "client-and-server"
     ]
   },
   {

--- a/app/pages/docs/client-and-server.mdx
+++ b/app/pages/docs/client-and-server.mdx
@@ -23,11 +23,8 @@ about [API Routes](./api-routes).
 
 #### React Components
 
-Everything inside a page or component file happens both server and client.
-However, you can opt-in for a full server-side rendering by exporting an
-async function called `getServerSideProps`. The server will call this
-function on every request. Read more about
-[`getServerSideProps`](./get-server-side-props).
+All code inside a page or component file runs on both server and client, except for 
+[`getServerSideProps`](./get-server-side-props) or [`getStaticProps`](./get-static-props). Code that is imported and ran inside those two functions will only run on the server.
 
 Since React components run both on the server and client, you might face
 issues accessing something only available on the client, such as `window`.

--- a/app/pages/docs/client-and-server.mdx
+++ b/app/pages/docs/client-and-server.mdx
@@ -1,0 +1,38 @@
+---
+id: client-and-server
+title: Client and Server
+sidebar_label: Client and Server
+---
+
+Blitz is focused on making the communication between server and client
+seamless. That means you can import and use server code directly in your
+UI components. However, you might be wondering what runs on the server and
+what runs on the client. Here's a quick overview.
+
+#### Queries and mutations
+
+Queries and mutations only run on the server — at build time, the direct
+function import is replaced with an RPC network call. So the query
+function code is never included in your client code. It's instead moved to
+an API layer.
+
+#### API Routes
+
+API handlers defined in `api/` directory run only on the server. Read more
+about [API Routes](link).
+
+#### React Components
+
+Everything inside a page or component file happens both server and client.
+However, you can opt-in for a full server-side rendering by exporting an
+async function called `getServerSideProps`. The server will call this
+function on every request. Read more about
+[`getServerSideProps`](./get-server-side-props).
+
+Since React components run both on the server and client, you might face
+issues accessing something only available on the client, such as `window`.
+Remember to check for `undefined` when using it in React render functions.
+
+Some data doesn't exist on the client's first render (e.g. session), which
+causes a quick "flash". You can use
+`Page.suppressFirstRenderFlicker = true` to hide the first render.

--- a/app/pages/docs/client-and-server.mdx
+++ b/app/pages/docs/client-and-server.mdx
@@ -19,7 +19,7 @@ an API layer.
 #### API Routes
 
 API handlers defined in `api/` directory run only on the server. Read more
-about [API Routes](link).
+about [API Routes](./api-routes).
 
 #### React Components
 


### PR DESCRIPTION
I added a new page to the docs as per this comment: https://discord.com/channels/802917734999523368/891631382877569054/892170181458149416.

I wanted to summarize what's executed on the server versus what's on the client as it seems helpful to have this kind of summary. Let me know what you think!

I also wanted to include an architecture diagram but wasn't happy with how it looks and didn't want to modify the original svg too much. 

Though I think this diagram would be super helpful, so I'd create an issue for that after this PR is merged. Unless you like how it could look right now (it's not included in this PR):

<img width="1395" alt="Screenshot 2021-09-28 at 16 35 51" src="https://user-images.githubusercontent.com/9019397/135110482-233f032a-d168-4da2-a52c-ff6e2aefa849.png">

<img width="1397" alt="Screenshot 2021-09-28 at 16 35 45" src="https://user-images.githubusercontent.com/9019397/135110490-1bc65874-fb17-46e0-a592-2b866314f8bc.png">

