### PR TITLE
updated command docker compose up -d

### DIFF
--- a/app/pages/docs/postgres.mdx
+++ b/app/pages/docs/postgres.mdx
@@ -86,7 +86,7 @@ Please note that test database is using port `5433` instead of `5432`
 
 ```json
 "scripts": {
-    "predev": "docker-compose up -d",
+    "predev": "docker compose up -d",
     "dev": "blitz dev",
 }
 ```


### PR DESCRIPTION
the `docker-compose up` command -d requires that the `docker-compose` package is installed on the user's computer in addition to the docker package.
Now, docker supports the `compose` option natively. You can use `docker compose` instead.