### PR TITLE
Update useQuery and useMutation docs

### DIFF
--- a/app/pages/docs/use-mutation.mdx
+++ b/app/pages/docs/use-mutation.mdx
@@ -119,7 +119,8 @@ const promise = invoke(inputArguments, {
     `attempt => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000)`
     applies exponential backoff.
   - A function like `attempt => attempt * 1000` applies linear backoff.
-- `useErrorBoundary`
+- `useErrorBoundary: boolean`
+  - Optional
   - Defaults to the global query config's `useErrorBoundary` value, which
     is `false`
   - Set this to true if you want mutation errors to be thrown in the

--- a/app/pages/docs/use-query.mdx
+++ b/app/pages/docs/use-query.mdx
@@ -238,7 +238,8 @@ const [
 - `structuralSharing: boolean`
   - Optional
   - Defaults to `true`
-- `useErrorBoundary`
+- `useErrorBoundary: boolean`
+  - Optional
   - Defaults to the global query config's `useErrorBoundary` value, which
     is `false`
   - Set this to true if you want query errors to be thrown in the

--- a/app/pages/docs/use-query.mdx
+++ b/app/pages/docs/use-query.mdx
@@ -238,6 +238,11 @@ const [
 - `structuralSharing: boolean`
   - Optional
   - Defaults to `true`
+- `useErrorBoundary`
+  - Defaults to the global query config's `useErrorBoundary` value, which
+    is `false`
+  - Set this to true if you want query errors to be thrown in the
+    render phase and propagate to the nearest error boundary.
 
 ### Returns {#returns}
 


### PR DESCRIPTION
Updated the useQuery documentation to include a description of the useErrorBoundary option. I also tweaked the useMutation docs to include useErrorBoundary's type.

Resolves #548 