### PR TITLE
add a troubleshooting part with debug logging

### DIFF
--- a/app/core/navs/documentation.json
+++ b/app/core/navs/documentation.json
@@ -50,7 +50,8 @@
       "error-boundary",
       "testing",
       "utilities",
-      "client-and-server"
+      "client-and-server",
+      "troubleshooting"
     ]
   },
   {

--- a/app/pages/docs/troubleshooting.mdx
+++ b/app/pages/docs/troubleshooting.mdx
@@ -27,19 +27,19 @@ DEBUG=blitz:* blitz console
 
 Here are the namespace used by Blitz :
 
-- blitz:cli
-- blitz:config
-- blitz:generate
-- blitz:generator
-- blitz:installer
-- blitz:manifest
-- blitz:middleware
-- blitz:new
-- blitz:postinstall
-- blitz:repl
-- blitz:rpc
-- blitz:session
-- blitz:utils
+- `blitz:cli`
+- `blitz:config`
+- `blitz:generate`
+- `blitz:generator`
+- `blitz:installer`
+- `blitz:manifest`
+- `blitz:middleware`
+- `blitz:new`
+- `blitz:postinstall`
+- `blitz:repl`
+- `blitz:rpc`
+- `blitz:session`
+- `blitz:utils`
 
 ### Usage in the browser {#usage-in-the-browser}
 
@@ -51,5 +51,4 @@ namespace used by Blitz and then refresh the page.
 localStorage.setItem('debug', 'blitz:*')
 ```
 
-Please also be sure, that the devtools console, has the verbose level
-enabled.
+Please, be sure that the devtools console has the verbose level enabled.

--- a/app/pages/docs/troubleshooting.mdx
+++ b/app/pages/docs/troubleshooting.mdx
@@ -48,7 +48,7 @@ To do so simply set the local storage variable debug to `blitz:*` or any
 namespace used by Blitz and then refresh the page.
 
 ```
-localStorage.setItem('debug', 'blitz:*')
+localStorage.debug = 'blitz:*'
 ```
 
 Please, be sure that the devtools console has the verbose level enabled.

--- a/app/pages/docs/troubleshooting.mdx
+++ b/app/pages/docs/troubleshooting.mdx
@@ -40,3 +40,16 @@ Here are the namespace used by Blitz :
 - blitz:rpc
 - blitz:session
 - blitz:utils
+
+### Usage in the browser {#usage-in-the-browser}
+
+You can also have this kind of logging for the client-side part of Blitz.
+To do so simply set the local storage variable debug to `blitz:*` or any
+namespace used by Blitz and then refresh the page.
+
+```
+localStorage.setItem('debug', 'blitz:*')
+```
+
+Please also be sure, that the devtools console, has the verbose level
+enabled.

--- a/app/pages/docs/troubleshooting.mdx
+++ b/app/pages/docs/troubleshooting.mdx
@@ -1,0 +1,42 @@
+---
+id: troubleshooting
+title: Troubleshooting
+sidebar_label: Troubleshooting
+---
+
+## Debug logging {#debug-logging}
+
+If you need a more verbose experience on any Blitz module, for debugging
+purpose, you can enable advanced logging using the DEBUG environment
+variable.
+
+Blitz internally use [debug](https://www.npmjs.com/package/debug) package.
+
+For example, if you want to enable the REPL logging you can run the
+console like so :
+
+```
+DEBUG=blitz:repl blitz console
+```
+
+You can also use a wildcard pattern :
+
+```
+DEBUG=blitz:* blitz console
+```
+
+Here are the namespace used by Blitz :
+
+- blitz:cli
+- blitz:config
+- blitz:generate
+- blitz:generator
+- blitz:installer
+- blitz:manifest
+- blitz:middleware
+- blitz:new
+- blitz:postinstall
+- blitz:repl
+- blitz:rpc
+- blitz:session
+- blitz:utils


### PR DESCRIPTION
During my investigation on https://github.com/blitz-js/blitz/pull/2792, I discovered the `DEBUG` environment variable.
I think this variable could have helped the reporter of https://github.com/blitz-js/blitz/issues/2751 to troubleshoot his issue on Blitz console.

I initiated a new section `troubleshooting` that can contains a lot of tips like that.
That could be a "must read" for future users that encounter an issue and need help debugging their Blitz projects.

Hope you'll like this 😄 