### PR TITLE
fix: Navigate to docs url on enter/return key

### DIFF
--- a/app/core/components/Search.js
+++ b/app/core/components/Search.js
@@ -80,9 +80,9 @@ export function Search({className = ""}) {
             apiKey="c4db860ae4162be48d4c867e33edcaa2"
             appId="BH4D9OD16A"
             navigator={{
-              navigate({suggestionUrl}) {
+              navigate({itemUrl}) {
                 setIsOpen(false)
-                router.push(suggestionUrl)
+                router.push(itemUrl)
               },
             }}
             hitComponent={Hit}


### PR DESCRIPTION
Fixes navigating in docs via search + enter/return key. 

Url is passed as itemUrl https://github.com/algolia/autocomplete/blob/82d1c206d6e4128ab93d9cd1ce7b59a3760b16ec/packages/autocomplete-core/src/types/AutocompleteNavigator.ts#L9 

before it was navigating to undefined