### PR TITLE
Update --parent documenation in cli-generate.mdx

### DIFF
--- a/app/pages/docs/cli-generate.mdx
+++ b/app/pages/docs/cli-generate.mdx
@@ -103,6 +103,9 @@ app/tasks/mutations/deleteTask.ts
 app/tasks/mutations/updateTask.ts
 ```
 
+Note that this will not generate the relationships between the models,
+only the queries, mutations and pages.
+
 ##### `--dry-run`
 
 Shorthand: `-d`


### PR DESCRIPTION
It took me longer than it should have done to understand the distinction between using the `--parent` flag and using `belongsTo:model` notation.

To generate the pages, mutations, queries AND model relationships for a parent:child pairing of models, you need to use both the `--parent` flag and set the `belongsTo:model` relationship.

I think the lines I have added to the docs are the minimal needed change to surface this info.

