### PR TITLE
fix: typo on folder name - Session Management page

### DIFF
--- a/app/pages/docs/session-management.mdx
+++ b/app/pages/docs/session-management.mdx
@@ -48,7 +48,7 @@ causing all queries on the page to be refetched. This ensures any
 sensitive data in the cache is deleted.
 
 ```ts
-// app/auth/muations/logout.ts
+// app/auth/mutations/logout.ts
 import { Ctx } from "blitz"
 
 export default async function logout(_: any, ctx: Ctx) {


### PR DESCRIPTION
This is a simple PR to replace `muations` with `mutations`