### PR TITLE
Fix import of log in custom server example

### DIFF
--- a/app/pages/docs/custom-server.mdx
+++ b/app/pages/docs/custom-server.mdx
@@ -23,7 +23,7 @@ Here's an example custom server:
 import blitz from "blitz/custom-server"
 import { createServer } from "http"
 import { parse } from "url"
-import { log } from "@blitzjs/display"
+import { log } from "next/dist/server/lib/logging"
 
 const { PORT = "3000" } = process.env
 const dev = process.env.NODE_ENV !== "production"


### PR DESCRIPTION
The import of `log` in the docs example no longer works in the latest version of Blitz.