### PR TITLE
Fix docker-compose command typo

### DIFF
--- a/app/pages/docs/postgres.mdx
+++ b/app/pages/docs/postgres.mdx
@@ -86,7 +86,7 @@ Please note that test database is using port `5433` instead of `5432`
 
 ```json
 "scripts": {
-    "predev": "docker compose up -d",
+    "predev": "docker-compose up -d",
     "dev": "blitz dev",
 }
 ```


### PR DESCRIPTION
There's a typo on the `pre-dev` script for the `docker-compose` command.