### PR TITLE
Add information about Blitz pivot

### DIFF
--- a/app/core/components/Banner.js
+++ b/app/core/components/Banner.js
@@ -1,8 +1,8 @@
-const Banner = ({message, hasLightBg}) => (
+const Banner = ({message, hasLightBg, className = ""}) => (
   <div
     className={`border-b border-opacity-50 border-primary ${
       hasLightBg ? "text-black dark:text-dark-mode-text" : "text-white"
-    }`}
+    } ${className}`}
   >
     <div className="font-semibold max-w-7xl mx-auto pt-1 pb-2 md:pt-0 md:pb-3 px-3 sm:px-6 lg:px-8 text-sm text-center">
       {message}

--- a/app/core/components/Header.js
+++ b/app/core/components/Header.js
@@ -1,5 +1,6 @@
 import {Link} from "blitz"
-import {useRouter} from "blitz"
+import {setCookie, useRouter} from "blitz"
+import clsx from "clsx"
 import {useEffect, useState} from "react"
 import {AiOutlineClose, AiOutlineMenu} from "react-icons/ai"
 import {FaDiscord, FaGithub, FaTwitter} from "react-icons/fa"
@@ -50,6 +51,30 @@ const SocialIcons = ({className, variant}) => {
     </div>
   )
 }
+const bannerMsg = (
+  <div>
+    🚀
+    <a
+      href="https://flightcontrol.dev?ref=blitzjs"
+      rel="noreferrer"
+      target="_blank"
+      className="underline"
+    >
+      Announcing Flightcontrol
+    </a>{" "}
+    - Optimized Deployment for Fullstack Blitz.js and Next.js 🚀
+  </div>
+)
+
+const blitzPivotMsg = (
+  <div>
+    ❗️ Blitz pivots to a framework agnostic toolkit.{" "}
+    <span className="underline">
+      <Link href="/docs/blitz-pivot">Click to read more.</Link>{" "}
+    </span>
+    ❗️
+  </div>
+)
 
 const Header = ({
   className = "",
@@ -80,25 +105,10 @@ const Header = ({
     onNavToggle(newValue)
   }
 
-  const bannerMsg = (
-    <div>
-      🚀
-      <a
-        href="https://flightcontrol.dev?ref=blitzjs"
-        rel="noreferrer"
-        target="_blank"
-        className="underline"
-      >
-        Announcing Flightcontrol
-      </a>{" "}
-      - Optimized Deployment for Fullstack Blitz.js and Next.js 🚀
-    </div>
-  )
-
   const menuLinks = [
     {
       name: "Documentation",
-      href: isDesktop ? "/docs/get-started" : "/docs",
+      href: isDesktop ? "/docs/blitz-pivot" : "/docs",
     },
     {
       name: "Showcase",
@@ -111,7 +121,8 @@ const Header = ({
 
   return (
     <>
-      {bannerMsg && <Banner message={bannerMsg} hasLightBg={hasLightBg} />}
+      <Banner message={blitzPivotMsg} hasLightBg={hasLightBg} />
+      {bannerMsg && <Banner message={bannerMsg} hasLightBg={hasLightBg} className="pt-3" />}
       <nav className={`${stickyBgClass ? "sticky top-0 z-50" : ""}`}>
         <div className={`flex items-center justify-between lg:mt-4 ${className} ${stickyBgClass}`}>
           <div className="pr-8 xl:pr-12 lg:-mt-3">

--- a/app/core/components/Header.js
+++ b/app/core/components/Header.js
@@ -1,6 +1,5 @@
 import {Link} from "blitz"
-import {setCookie, useRouter} from "blitz"
-import clsx from "clsx"
+import {useRouter} from "blitz"
 import {useEffect, useState} from "react"
 import {AiOutlineClose, AiOutlineMenu} from "react-icons/ai"
 import {FaDiscord, FaGithub, FaTwitter} from "react-icons/fa"

--- a/app/core/layouts/SidebarLayout.js
+++ b/app/core/layouts/SidebarLayout.js
@@ -102,7 +102,7 @@ export function SidebarLayout({children, nav, sidebar, fallbackHref, tableOfCont
 
   useEffect(() => {
     if (isDesktop && isDocsIndex) {
-      router.push("/docs/get-started")
+      router.push("/docs/blitz-pivot")
     }
   }, [router, isDesktop, isDocsIndex])
 

--- a/app/core/navs/documentation.json
+++ b/app/core/navs/documentation.json
@@ -6,6 +6,7 @@
       "iconDarkPath": "/img/introduction-white.svg"
     },
     "pages": [
+      "blitz-pivot",
       "get-started",
       "tutorial",
       "learning-path",

--- a/app/pages/docs/blitz-pivot.mdx
+++ b/app/pages/docs/blitz-pivot.mdx
@@ -16,7 +16,7 @@ tookit as seamless as possible.
 ## Pivot Objectives {#objectives}
 
 - Preserve the DX and features we currently have
-- Make it easy for millions more of developers to benefit from Blitz
+- Make it effortless for millions more of developers to benefit from Blitz
 - Decouple Blitz from any specific framework
 
 Blitz toolkit will be meant for building anything with a database, from

--- a/app/pages/docs/blitz-pivot.mdx
+++ b/app/pages/docs/blitz-pivot.mdx
@@ -1,0 +1,48 @@
+---
+title: Blitz Pivot
+sidebar_label: Blitz Pivot
+---
+
+**Blitz pivots to a framework agnostic toolkit that preserves the
+world-class DX and features we adore but brings it to all Next.js users
+and optionally Remix, SvelteKit, Nuxt, etc.**
+
+Your existing Blitz apps will continue to run, and we will fix any
+critical bugs that come up. The current blitz codebase will remain. It may
+move to a different repo, but it will be preserved and we can continue to
+make releases as needed. We'll strive to make the migration to the Blitz
+tookit as seamless as possible.
+
+## Pivot Objectives {#objectives}
+
+- Preserve the DX and features we currently have
+- Make it easy for millions more of developers to benefit from Blitz
+- Decouple Blitz from any specific framework
+
+Blitz toolkit will be meant for building anything with a database, from
+side projects to massive enterprise apps. It will both enhance fullstack
+DX and provide the missing backend components for JS that Rails and
+Laravel enjoy.
+
+## Features {#features}
+
+We believe the core value that Blitz currently provides is:
+
+1. The zero-api data layer,
+2. Authentication,
+3. Authorization,
+4. Conventions,
+5. New app templates & code scaffolding.
+
+A new toolkit would start with these as the foundation. We think almost
+everything Blitz currently adds would be migrated to the toolkit including
+recipes, typesafe Routes manifest, etc. Then we’d start shipping a ton
+more awesome things.
+
+## Further reading {#further-reading}
+
+For more details check out
+[the Blitz Pivot RFC](https://github.com/blitz-js/blitz/discussions/3075).
+It includes an outline of the toolkit, and a list of the features we’d
+like to see. It also covers where the pivot is coming from as well as
+possible future directions.


### PR DESCRIPTION
I added a new page to the docs (to the `introduction` section, which I'm not sure is the best place?), a new banner informing about the pivot and pointing to the docs. I also made the redirects to `blitz-pivot` instead of `getting-started` as I thought it can be beneficial for people to first learn about the pivot before diving into getting started. No strong opinions here, though.