### PR TITLE
[STYLE FIX]: Email input box style fix in footer

### DIFF
--- a/app/core/components/home/NewsletterForm.js
+++ b/app/core/components/home/NewsletterForm.js
@@ -8,7 +8,9 @@ const NewsletterForm = ({className, hasDarkMode}) => {
     <form
       action="https://design.us4.list-manage.com/subscribe/post?u=aeb422edfecb0e2dcaf70d12d&amp;id=1a028d02ce"
       method="post"
-      className={`relative ${className}`}
+      className={`relative ${className} border ${
+        hasDarkMode ? "border-blue-light dark:border-white" : "border-white"
+      } border-opacity-50 rounder-sm font-secondary`}
     >
       <input
         aria-label="Email Address"
@@ -16,9 +18,7 @@ const NewsletterForm = ({className, hasDarkMode}) => {
         type="email"
         required
         placeholder="Enter Your Email Address"
-        className={`w-full p-2 text-base placeholder-current bg-transparent border ${
-          hasDarkMode ? "border-blue-light dark:border-white" : "border-white"
-        } border-opacity-50 rounded-sm font-secondary`}
+        className={`w-[90%] p-2 text-base placeholder-current bg-transparent outline-none`}
       />
       <button className="absolute right-0 mt-2 mr-2" type="submit">
         <BsArrowRight size="1.5rem" className="justify-self-end" />


### PR DESCRIPTION
Currently in the documentation, if an email is very lengthy, it will overlap with the button(Icon). This PR is intended to fix that particular style issue.