### PR TITLE
Fix long words in code sticking out of the content box

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -181,6 +181,7 @@ module.exports = {
               color: "#280088",
               backgroundColor: "#f2f0fd",
               borderRadius: 3,
+              overflowWrap: "break-word",
             },
             "pre code": {
               color: theme("colors.black"),


### PR DESCRIPTION
fix #655

![image](https://user-images.githubusercontent.com/3516343/155592167-41805887-7360-4774-8c07-f3dc487a8ec6.png)
Preview: https://blitzjs-com-git-fork-eai04191-fix-code-wrap-blitzjs.vercel.app/docs/pages


`overflow-wrap: break-word` is also used in the `code` on GitHub and seems to be suitable for this usage.