### PR TITLE
"lint" the home page code editor inconsistency

### DIFF
--- a/app/core/components/home/HeroCode.js
+++ b/app/core/components/home/HeroCode.js
@@ -10,7 +10,7 @@ const pageTokenized = tokenize.jsx(
 import { Link, Routes, useRouter, useMutation, BlitzPage } from "blitz"
 import Layout from "app/core/layouts/Layout"
 // Notice how we import the server function directly
-import createProject, {CreateProject} from "app/projects/mutations/createProject"
+import createProject, { CreateProject } from "app/projects/mutations/createProject"
 import { ProjectForm } from "app/projects/components/ProjectForm"
 
 const NewProjectPage: BlitzPage = () => {


### PR DESCRIPTION
Fixes this inconsistency:
![image](https://user-images.githubusercontent.com/25233323/156934948-7c55d008-e2c5-4afe-82b4-b987cc3b00a9.png)

From:
```
import createProject, {CreateProject} from "app/projects/mutations/createProject"
```

To:
```
import createProject, { CreateProject } from "app/projects/mutations/createProject"
```