### PR TITLE
updating supertokens url in auth docs

### DIFF
--- a/app/pages/docs/auth.mdx
+++ b/app/pages/docs/auth.mdx
@@ -12,6 +12,6 @@ Blitz has built-in session management that works with email/password auth
 and with any third-party providers.
 
 Blitz session management follows the same approach as the state of the art
-[SuperTokens library](https://supertokens.io). The CTO of SuperTokens,
+[SuperTokens library](https://supertokens.com). The CTO of SuperTokens,
 [Rishabh Poddar](https://twitter.com/rishpoddar), designed and oversaw our
 implementation. We're extremely grateful for Rishabh's help! 🙏


### PR DESCRIPTION
SuperTokens recently changed its URL from supertokens.io -> supertokens.com, this PR reflects that change