### PR TITLE
Add missing instructions for contributors

### DIFF
--- a/app/pages/docs/contributing.mdx
+++ b/app/pages/docs/contributing.mdx
@@ -108,6 +108,8 @@ the PR.
 
 ## Development Setup {#development-setup}
 
+first make sure you're using node 14, our version of `node-sass` does not work with newer versions and will show a scary and unclear error if tried!
+
 **1.** Fork [the blitz repo](https://github.com/blitz-js/blitz)
 
 **2.** Clone your forked repo
@@ -118,13 +120,21 @@ git clone git@github.com:USERNAME/blitz.git
 cd blitz
 ```
 
-**3.** Install dependencies
+**3.** Install required packages for `sodium-native`
+
+on mac
+
+```sh
+brew install autoconf automake
+```
+
+**4.** Install dependencies
 
 ```sh
 yarn
 ```
 
-**4.** Start the package server. This **must be running** for any package
+**5.** Start the package server. This **must be running** for any package
 development or example development
 
 ```sh

--- a/app/pages/docs/contributing.mdx
+++ b/app/pages/docs/contributing.mdx
@@ -108,7 +108,8 @@ the PR.
 
 ## Development Setup {#development-setup}
 
-first make sure you're using node 14, our version of `node-sass` does not work with newer versions and will show a scary and unclear error if tried!
+Make sure you're using Node 14 — Next uses `node-sass` which does not work
+with newer Node versions.
 
 **1.** Fork [the blitz repo](https://github.com/blitz-js/blitz)
 
@@ -120,9 +121,11 @@ git clone git@github.com:USERNAME/blitz.git
 cd blitz
 ```
 
-**3.** Install required packages for `sodium-native`
+**3.** (Optional, macOS only) Install required packages for
+`sodium-native`
 
-on mac
+If you spot any issues related to `sodium-native`, run the following
+command to fix it:
 
 ```sh
 brew install autoconf automake


### PR DESCRIPTION
While trying to set up the blitz projec on my macbook, I've encountered a few obstacles.
I've wrote them down, fixed them, and added the steps to the contribution guide!

The node 14 restriction should be fix if node-sass is updated to beyond 6.0.1 or something like that.
`sodium-native` that I honestly don't know what it does requires `autoconf` and `automake` to be installed my your mac machine

Hope this helps!

EDIT: now working on the new toolkit, I'm guessing it might not be relevant anymore and will be re-written. If thats the case feel free to close this PR :)
