### PR TITLE
fix dead link

### DIFF
--- a/app/pages/docs/get-started.mdx
+++ b/app/pages/docs/get-started.mdx
@@ -57,7 +57,7 @@ How you can help:
    [opening an issue on GitHub](https://github.com/blitz-js/blitz/issues/new/choose)
 1. Contribute code:
    [Read the contributing guide so see how to get started](./contributing).
-1. [Sponsorships & donations](https://github.com/blitz-js/blitz#sponsors-and-donations),
+1. [Sponsorships & donations](https://github.com/blitz-js/blitz#financial-contributors),
    which start at $5/month
 1. Any other way you want! We totally appreciate any type of contribution,
    such as documentation, videos, blog posts, etc. If you have an unusual


### PR DESCRIPTION
The named anchor `https://github.com/blitz-js/blitz#sponsors-and-donations` doesn't exist anymore.
Replaced it with `https://github.com/blitz-js/blitz#financial-contributors`.