### PR TITLE
docs: Wrap passport example with api() from blitz-server

### DIFF
--- a/app/pages/docs/passportjs.mdx
+++ b/app/pages/docs/passportjs.mdx
@@ -20,9 +20,10 @@ contents.
 ```ts
 // app/api/auth/[...auth].ts
 import { passportAuth } from "blitz"
+import { api } from "app/blitz-server"
 import db from "db"
 
-export default passportAuth({
+export default api(passportAuth({
   successRedirectUrl: "/",
   errorRedirectUrl: "/",
   strategies: [
@@ -30,7 +31,7 @@ export default passportAuth({
       strategy: new PassportStrategy(), // Provide initialized passport strategy here
     },
   ],
-})
+}))
 ```
 
 If you need, you can place the api route at a different path but the


### PR DESCRIPTION
No clue why #700 was closed, this is exactly the same change.

`PassportAuth()` should be wrapped with `api()`, similar to how it's done at https://github.com/blitz-js/blitzjs.com/blob/d61b7176f9d5789397d0b8954cd64eb25bd26077/app/pages/docs/rpc-setup.mdx#blitz-rpc-with-nextjs-setup-nextjs.

Fixes blitz-js/blitz#3467.