### PR TITLE
Update blitz-with-next.mdx

### DIFF
--- a/app/pages/docs/blitz-with-next.mdx
+++ b/app/pages/docs/blitz-with-next.mdx
@@ -74,7 +74,7 @@ function App({ Component, pageProps }: AppProps) {
 export default withBlitz(App)
 ```
 
-## Modyfing `next.config.js` file {#modifying-next-config-file}
+## Modifying `next.config.js` file {#modifying-next-config-file}
 
 Next.js requires you to manually type out page locations. Blitz comes with
 a [Route Manifest](./route-manifest), so you can do:


### PR DESCRIPTION
fixed typo on documentation page (from 'Modyfing' to 'Modifying')