### PR TITLE
Update CTA link

### DIFF
--- a/app/core/navs/documentation.json
+++ b/app/core/navs/documentation.json
@@ -6,9 +6,9 @@
       "iconDarkPath": "/img/introduction-white.svg"
     },
     "pages": [
+      "why-blitz",
       "get-started",
       "learning-path",
-      "why-blitz",
       "tutorial",
       "blitz-with-next",
       "upgrading-from-framework",

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -64,7 +64,7 @@ const Home = ({randomContributors}) => {
                     conventions for shipping and scaling world wide applications.
                   </p>
                   <div className="flex space-x-4 mt-10">
-                    <ButtonLink className="w-2/3 lg:w-auto rounded-tl-xl" href="/docs/get-started">
+                    <ButtonLink className="w-2/3 lg:w-auto rounded-tl-xl" href="/docs/why-blitz">
                       Learn to Blitz
                     </ButtonLink>
                     <ButtonLink


### PR DESCRIPTION
- move why blitz up in the documentation sidebar
- update cta link to point to why-blitz