### PR TITLE
3811 move useCurrentUser hook

### DIFF
--- a/app/pages/docs/authorization.mdx
+++ b/app/pages/docs/authorization.mdx
@@ -298,7 +298,7 @@ in the session's `publicData`, you would need to use `useCurrentUser()`
 instead of `useSession()`.
 
 ```tsx
-import { useCurrentUser } from "app/core/hooks/useCurrentUser"
+import { useCurrentUser } from "app/users/hooks/useCurrentUser"
 
 const user = useCurrentUser()
 

--- a/app/pages/docs/file-structure.mdx
+++ b/app/pages/docs/file-structure.mdx
@@ -19,8 +19,6 @@ sidebar_label: File Structure
 │   │   ├── components/
 │   │   │   ├── Form.tsx
 │   │   │   └── LabeledTextField.tsx
-│   │   ├── hooks/
-│   │   │   └── useCurrentUser.ts
 │   │   └── layouts/
 │   │       └── Layout.tsx
 │   ├── auth/
@@ -34,6 +32,8 @@ sidebar_label: File Structure
 │   │   ├── auth-utils.ts
 │   │   └── validations.ts
 │   ├── users/
+│   │   ├── hooks/
+│   │   │   └── useCurrentUser.ts
 │   │   └── queries/
 │   │       └── getCurrentUser.ts
 │   └── projects/

--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -55,11 +55,11 @@ my-blitz-app
 │   │   ├── components/
 │   │   │   ├── Form.tsx
 │   │   │   └── LabeledTextField.tsx
-│   │   ├── hooks/
-│   │   │   └── useCurrentUser.ts
 │   │   └── layouts/
 │   │       └── Layout.tsx
 │   ├── users/
+│   │   ├── hooks/
+│   │   │   └── useCurrentUser.ts
 │   │   └── queries/
 │   │       └── getCurrentUser.ts
 │   ├── blitz-client.ts


### PR DESCRIPTION
Update docs.

depends on this PR.
https://github.com/blitz-js/blitz/pull/3831

changes:

from `users/hooks/useCurrentUser.ts` to `users/hooks/useCurrentUser.ts`