### PR TITLE
Add restart Blitz instruction in Tutorial

### DIFF
--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -829,7 +829,7 @@ code beneath the `Link` in our `QuestionsList`:
 // ...
 ```
 
-Now check `/questions` in the browser. **Magic!**
+Restart Blitz. Now check `/questions` in the browser. **Magic!**
 
 ## Let’s let people vote on these questions! {#let-people-vote-on-questions}
 

--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -829,7 +829,7 @@ code beneath the `Link` in our `QuestionsList`:
 // ...
 ```
 
-Restart Blitz. Now check `/questions` in the browser. **Magic!**
+Restart your app — stop dev server and run `yarn dev`, `npm dev`, or `pnpm dev` again. Now check `/questions` in the browser. **Magic!**
 
 ## Let’s let people vote on these questions! {#let-people-vote-on-questions}
 


### PR DESCRIPTION
This PR adds instructions to restart Blitz in the Tutorial in order to avoid an `undefined` error.

Fixes #753 