### PR TITLE
Update blitz-auth docs

### DIFF
--- a/app/core/navs/documentation.json
+++ b/app/core/navs/documentation.json
@@ -67,9 +67,12 @@
       "auth",
       "auth-setup",
       "session-management",
+      "auth-server",
+      "auth-client",
       "authorization",
       "passportjs",
       "auth-utils",
+      "auth-config",
       "impersonation"
     ]
   },

--- a/app/pages/docs/auth-client.mdx
+++ b/app/pages/docs/auth-client.mdx
@@ -1,0 +1,47 @@
+---
+title: Auth Client Usage
+sidebar_label: Client Usage
+---
+
+Blitz provides a `useSession()` hook that returns
+[`PublicData`](#publicdata) with `isLoading` property. This hook can be
+used anywhere in your application.
+
+Note: `useSession()` uses suspense by default, so you need a `<Suspense>`
+component above it in the tree. Or you can set
+`useSession({suspense: false})` to disable suspense.
+
+```ts
+import { useSession } from "@blitzjs/auth"
+
+function SomeComponent() {
+  const session = useSession()
+
+  session.userId
+  session.role
+
+  return /*... */
+}
+```
+
+If you are using
+[`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props),
+then you can pass the session public data to `useSession()` with the
+`initialPublicData` option.
+
+```ts
+import { useSession, getSession } from "@blitzjs/auth"
+import { gSSP } from "src/blitz-server"
+
+export const getServerSideProps = gSSP(async ({ req, res }) => {
+  const session = await getSession(req, res)
+
+  return { props: { initialPublicData: session.$publicData } }
+})
+
+const SomePage: BlitzPage = ({ initialPublicData }) => {
+  const session = useSession({ initialPublicData })
+
+  return /*... */
+}
+```

--- a/app/pages/docs/auth-config.mdx
+++ b/app/pages/docs/auth-config.mdx
@@ -1,0 +1,106 @@
+---
+title: Configuration
+sidebar_label: Auth Configuration
+---
+
+## Session Configuration {#session-configuration}
+
+You can customize session management by passing an object to the
+`AuthServerPlugin()` in `src/blitz-server`.
+
+```ts
+// src/blitz-server.ts
+import { AuthServerPlugin, PrismaStorage } from "@blitzjs/auth"
+import { simpleRolesIsAuthorized } from "@blitzjs/auth"
+
+setupBlitzServer({
+  plugins: [
+    AuthServerPlugin({
+      cookiePrefix: "web-cookie-prefix",
+      storage: PrismaStorage(db),
+      isAuthorized: simpleRolesIsAuthorized,
+    }),
+  ],
+})
+```
+
+Available options:
+
+```ts
+type SessionConfig = {
+  cookiePrefix?: string /* Default: 'blitz' */
+  sessionExpiryMinutes?: number /* Default: 30 days */
+  anonSessionExpiryMinutes?: number /* Default: 5 years */
+  sameSite?: "strict" | "lax" | "none" /* Default: 'lax'. 
+    If you set this to 'none', you also have to set `secureCookies: true`. 
+    See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite */
+  method?: "essential" | "advanced" /* Default: 'essential' */
+  secureCookies?: boolean /* Default: undefined. This flag is skipped if running app on hostname `localhost` */
+  domain?: string /* Default: undefined. Can set as `.yourDomain.com` to work across subdomains */
+  publicDataKeysToSyncAcrossSessions?: string[] /* Default: ['role', 'roles'] */
+  getSession: (handle: string) => Promise<SessionModel | null>
+  getSessions: (userId: string | number) => Promise<SessionModel[]>
+  createSession: (session: SessionModel) => Promise<SessionModel>
+  updateSession: (
+    handle: string,
+    session: Partial<SessionModel>
+  ) => Promise<SessionModel>
+  deleteSession: (handle: string) => Promise<SessionModel>
+  isAuthorized: ({ ctx: any, args: [...unknown] }) => boolean
+}
+```
+
+## Customize Session Persistence & Database Access {#customize-session-persistence-and-database-access}
+
+By default, session persistence is zero-config with `PrismaStorage`.
+However, you can customize this to save sessions somewhere else, like
+Redis. You can also customize this if you have Prisma but want to
+customize the attribute names on the user or session model.
+
+Customize session persistence by overriding the database access functions.
+The functions can do anything, but they must conform to the defined input
+and outputs types.
+
+```typescript
+import { setupBlitzServer } from "@blitzjs/next"
+import {
+  AuthServerPlugin,
+  PrismaStorage,
+  simpleRolesIsAuthorized,
+} from "@blitzjs/auth"
+
+const { gSSP, gSP, api } = setupBlitzServer({
+  plugins: [
+    AuthServerPlugin({
+      cookiePrefix: "blitz-app-prefix",
+      isAuthorized: simpleRolesIsAuthorized,
+      storage: {
+        getSession: (handle) => redis.get(`session:${handle}`),
+        createSession: (session) =>
+          redis.set(`session:${handle}`, session),
+        deleteSession: (handle) => redis.del(`session:${handle}`),
+        // ...
+      },
+    }),
+  ],
+})
+
+export { gSSP, gSP, api }
+```
+
+[**Here's a GitHub gist with a full Redis example.**](https://gist.github.com/beerose/80f37b4b36cbd7ba2745701959e3cb8b)
+
+The storage methods need to conform to the following interface:
+
+```typescript
+interface SessionConfigMethods {
+  getSession: (handle: string) => Promise<SessionModel | null>
+  getSessions: (userId: PublicData["userId"]) => Promise<SessionModel[]>
+  createSession: (session: SessionModel) => Promise<SessionModel>
+  updateSession: (
+    handle: string,
+    session: Partial<SessionModel>
+  ) => Promise<SessionModel | undefined>
+  deleteSession: (handle: string) => Promise<SessionModel>
+}
+```

--- a/app/pages/docs/auth-server.mdx
+++ b/app/pages/docs/auth-server.mdx
@@ -1,0 +1,39 @@
+---
+title: Auth Server Usage
+sidebar_label: Server Usage
+---
+
+### In Queries & Mutations {#in-queries-and-mutations}
+
+`SessionContext` is available off of `ctx` which is provided as the second
+parameter to all queries and mutations.
+
+```ts
+// src/queries/someQuery.ts
+import { Ctx } from "blitz"
+
+export default async function someQuery(input: any, ctx: Ctx) {
+  // Access the SessionContext class
+  ctx.session.userId
+  ctx.session.role
+  ctx.session.$create(/*...*/)
+
+  return
+}
+```
+
+### In `getServerSideProps` or API Routes {#in-get-server-side-props-or-api-routes}
+
+You can also get the session context inside `getServerSideProps` or inside
+API routes with `getSession` like this:
+
+```ts
+import { getSession } from "@blitzjs/auth"
+
+export const getServerSideProps = async ({ req, res }) => {
+  const session = await getSession(req, res)
+  console.log("User ID:", session.userId)
+
+  return { props: {} }
+}
+```

--- a/app/pages/docs/auth-setup.mdx
+++ b/app/pages/docs/auth-setup.mdx
@@ -37,54 +37,6 @@ const { gSSP, gSP, api } = setupBlitzServer({
 export { gSSP, gSP, api }
 ```
 
-The `storage` property is needed to handle session and user storage. You
-can use `PrismaStorage` and pass your Prisma client as in the example
-above. You can also define the storage methods yourself:
-
-```typescript
-import { setupBlitzServer } from "@blitzjs/next"
-import {
-  AuthServerPlugin,
-  PrismaStorage,
-  simpleRolesIsAuthorized,
-} from "@blitzjs/auth"
-
-const { gSSP, gSP, api } = setupBlitzServer({
-  plugins: [
-    AuthServerPlugin({
-      cookiePrefix: "blitz-app-prefix",
-      isAuthorized: simpleRolesIsAuthorized,
-      storage: {
-        getSession: (handle) => redis.get(`session:${handle}`),
-        createSession: (session) =>
-          redis.set(`session:${handle}`, session),
-        deleteSession: (handle) => redis.del(`session:${handle}`),
-        // ...
-      },
-    }),
-  ],
-})
-
-export { gSSP, gSP, api }
-```
-
-[**Here's a GitHub gist with a full Redis example.**](https://gist.github.com/beerose/80f37b4b36cbd7ba2745701959e3cb8b)
-
-The storage methods need to conform to the following interface:
-
-```typescript
-interface SessionConfigMethods {
-  getSession: (handle: string) => Promise<SessionModel | null>
-  getSessions: (userId: PublicData["userId"]) => Promise<SessionModel[]>
-  createSession: (session: SessionModel) => Promise<SessionModel>
-  updateSession: (
-    handle: string,
-    session: Partial<SessionModel>
-  ) => Promise<SessionModel | undefined>
-  deleteSession: (handle: string) => Promise<SessionModel>
-}
-```
-
 #### Client setup {#client-setup}
 
 Then, add the following to your `blitz-client.ts` file:

--- a/app/pages/docs/auth.mdx
+++ b/app/pages/docs/auth.mdx
@@ -6,7 +6,7 @@ sidebar_label: Overview
 New Blitz apps have authentication and authorization already set up by
 default with user sign-up, log-in, and log-out. Your `db/schema.prisma`
 file has a `User` and `Session` model and the auth code is in the
-`app/auth/` folder.
+`src/auth/` folder.
 
 Blitz has built-in session management that works with email/password auth
 and with any third-party providers.

--- a/app/pages/docs/session-management.mdx
+++ b/app/pages/docs/session-management.mdx
@@ -13,11 +13,13 @@ Session management performs the following functions:
    out
 3. Protection against CSRF attacks
 
-## TLDR {#tldr}
+<Card type="note">
+  You login, logout, and otherwise modify the session via the
+  [`SessionContext`](#sessioncontext) object which is [accessible anywhere
+  on the server](#access-session-on-the-server).
+</Card>
 
-You login, logout, and otherwise modify the session via the
-[`SessionContext`](#sessioncontext) object which is
-[accessible anywhere on the server](#access-session-on-the-server).
+## Basics {#session-basics}
 
 ### Login {#login}
 
@@ -25,7 +27,7 @@ For login you will have form component in your UI that will submit a login
 mutation like the one shown below.
 
 ```ts
-// app/auth/mutations/login.ts
+// src/auth/mutations/login.ts
 import { Ctx } from "blitz"
 
 export default async function login(input: SomeTSInputType, ctx: Ctx) {
@@ -84,89 +86,6 @@ passed. The default expiry time is 30 days. If you change the session’s
 [`PublicData`](#publicdata) the session is also automatically refreshed.
 You will need to update tokens (access and anti-CSRF) after a session
 refresh, if you use them (e.g. in a mobile app).
-
-## Access Session on the Server {#access-session-on-the-server}
-
-### In Queries & Mutations {#in-queries-and-mutations}
-
-[`SessionContext`](#sessioncontext) is available off of `ctx` which is
-provided as the second parameter to all queries and mutations because of
-the `sessionMiddleware` that's in `blitz.config.js`.
-
-```ts
-// app/queries/someQuery.ts
-import { Ctx } from "blitz"
-
-export default async function someQuery(input: any, ctx: Ctx) {
-  // Access the SessionContext class
-  ctx.session.userId
-  ctx.session.role
-  ctx.session.$create(/*...*/)
-
-  return
-}
-```
-
-### In `getServerSideProps` or API Routes {#in-get-server-side-props-or-api-routes}
-
-You can also get the session context inside `getServerSideProps` or inside
-API routes with `getSession` like this:
-
-```ts
-import { getSession } from "@blitzjs/auth"
-
-export const getServerSideProps = async ({ req, res }) => {
-  const session = await getSession(req, res)
-  console.log("User ID:", session.userId)
-
-  return { props: {} }
-}
-```
-
-## Access Session on the Client {#access-session-on-the-client}
-
-Blitz provides a `useSession()` hook that returns
-[`PublicData`](#publicdata) with `isLoading` property. This hook can be
-used anywhere in your application.
-
-Note: `useSession()` uses suspense by default, so you need a `<Suspense>`
-component above it in the tree. Or you can set
-`useSession({suspense: false})` to disable suspense.
-
-```ts
-import { useSession } from "@blitzjs/auth"
-
-function SomeComponent() {
-  const session = useSession()
-
-  session.userId
-  session.role
-
-  return /*... */
-}
-```
-
-If you are using
-[`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props),
-then you can pass the session public data to `useSession()` with the
-`initialPublicData` option.
-
-```ts
-import { useSession, getSession } from "@blitzjs/auth"
-import { gSSP } from "app/blitz-server"
-
-export const getServerSideProps = gSSP(async ({ req, res }) => {
-  const session = await getSession(req, res)
-
-  return { props: { initialPublicData: session.$publicData } }
-})
-
-const SomePage: BlitzPage = ({ initialPublicData }) => {
-  const session = useSession({ initialPublicData })
-
-  return /*... */
-}
-```
 
 ## Production Deployment Requirements {#production-deployment-requirements}
 
@@ -274,80 +193,6 @@ export default async function someQuery(input: any, ctx: Ctx) {
   return
 }
 ```
-
-## Session Configuration {#session-configuration}
-
-You can customize session management by passing an object to the
-`sessionMiddleware` factory function.
-
-```js
-// blitz.config.js
-const { sessionMiddleware, simpleRolesIsAuthorized } = require("blitz")
-
-module.exports = {
-  middleware: [
-    sessionMiddleware({
-      // highlight-start
-      cookiePrefix: "my-app",
-      sessionExpiryMinutes: 1234,
-      isAuthorized: simpleRolesIsAuthorized,
-      // highlight-end
-    }),
-  ],
-}
-```
-
-Available options:
-
-```ts
-type SessionConfig = {
-  cookiePrefix?: string /* Default: 'blitz' */
-  sessionExpiryMinutes?: number /* Default: 30 days */
-  anonSessionExpiryMinutes?: number /* Default: 5 years */
-  sameSite?: "strict" | "lax" | "none" /* Default: 'lax'. 
-    If you set this to 'none', you also have to set `secureCookies: true`. 
-    See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite */
-  method?: "essential" | "advanced" /* Default: 'essential' */
-  secureCookies?: boolean /* Default: undefined. This flag is skipped if running app on hostname `localhost` */
-  domain?: string /* Default: undefined. Can set as `.yourDomain.com` to work across subdomains */
-  publicDataKeysToSyncAcrossSessions?: string[] /* Default: ['role', 'roles'] */
-  getSession: (handle: string) => Promise<SessionModel | null>
-  getSessions: (userId: string | number) => Promise<SessionModel[]>
-  createSession: (session: SessionModel) => Promise<SessionModel>
-  updateSession: (
-    handle: string,
-    session: Partial<SessionModel>
-  ) => Promise<SessionModel>
-  deleteSession: (handle: string) => Promise<SessionModel>
-  isAuthorized: ({ ctx: any, args: [...unknown] }) => boolean
-}
-```
-
-```ts
-interface SessionModel extends Record<any, any> {
-  handle: string
-  userId?: string | number
-  expiresAt?: Date
-  hashedSessionToken?: string
-  antiCSRFToken?: string
-  publicData?: string
-  privateData?: string
-}
-```
-
-## Customize Session Persistence & Database Access {#customize-session-persistence-and-database-access}
-
-By default, session persistence is zero-config with Prisma. However, you
-can customize this to save sessions somewhere else, like Redis. You can
-also customize this if you have Prisma but want to customize the attribute
-names on the user or session model.
-
-Customize session persistence by overriding the database access functions
-defined above in `SessionConfig`. The functions can do anything, but they
-must conform to the defined input and outputs types.
-
-For reference, here's
-[the default config that works with Prisma](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/stdlib-server/auth-sessions.ts#L74).
 
 ## Manual API Requests {#manual-api-requests}
 


### PR DESCRIPTION
- Remove reference to the old `sessionMiddleware()`
- Reorganize `Session Management` page
- Create `Client Usage` & `Server Usage` pages
- Create Auth Config page with example on how to use other storage providers like Redis