### PR TITLE
cli-generate: Use src instead of app folder

### DIFF
--- a/app/pages/docs/cli-generate.mdx
+++ b/app/pages/docs/cli-generate.mdx
@@ -273,13 +273,13 @@ blitz generate model task subheading:string
 
 If you want to use custom templates with `blitz generate` instead of the
 default ones (e.g. with different styles). You can specify it in your
-`app/blitz-server` file by exporting the `cliConfig` object
+`src/blitz-server` file by exporting the `cliConfig` object
 
 ```ts
 import type { BlitzCliConfig } from "blitz"
 ...
 export const cliConfig: BlitzCliConfig = {
-  customTemplates: "app/templates",
+  customTemplates: "src/templates",
 }
 ```
 
@@ -292,4 +292,4 @@ blitz generate custom-templates
 The above command will generate the default templates used by blitz to a
 directory of your choosing in order to provide a starting point to use
 this feature. It will also update the `cliConfig` configuration, in the
-`app/blitz-server` file, with the latest data to allow immediate usage.
+`src/blitz-server` file, with the latest data to allow immediate usage.


### PR DESCRIPTION
See also https://github.com/blitz-js/blitz/pull/4033