### PR TITLE
Improve docs for `blitz start`, `blitz dev`, `blitz build`

### DIFF
--- a/app/pages/docs/cli-build.mdx
+++ b/app/pages/docs/cli-build.mdx
@@ -19,7 +19,9 @@ It does the following:
 
 #### Options
 
-none
+| Option                   | Shorthand | Description                                                                           | Default       |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------- | ------------- |
+| `--inspect`              |           | Enable the Node.js inspector                                                          | `false`       |
 
 #### Examples
 

--- a/app/pages/docs/cli-build.mdx
+++ b/app/pages/docs/cli-build.mdx
@@ -5,29 +5,21 @@ sidebar_label: blitz build
 
 **Alias: `blitz b`**
 
-Create a production build of your Blitz app. It compiles your Blitz app
+Create a **production build** of your Blitz app. It compiles your Blitz app
 into Next.js runtime code inside `.next`
 
 This is a super thin wrapper over Next CLI to improve environment variable
 loading.
 
-```bash
-blitz dev -e staging
-```
-
 It does the following:
 
-1. Loads correct `.env.X` and `.env.X.local` files based on the `-e X`
-   flag that you specify. Ex: `-e staging` loads `.env.staging`.
-2. Sets `process.env.APP_ENV` to the env name. Ex: `-e staging` =>
-   `APP_ENV=staging`.
-3. Passes all other arguments directly to the next build command
+1. Loads `.env.production`.
+2. Sets `process.env.APP_ENV` to `production`
+3. Passes all other arguments directly to the [`next build` command](https://nextjs.org/docs/api-reference/cli#build)
 
 #### Options
 
-| Option  | Shorthand | Description                                                                           | Default |
-| ------- | --------- | ------------------------------------------------------------------------------------- | ------- |
-| `--env` | `-e`      | Set app environment name. [Read more](/docs/custom-environments#custom-environments). | None    |
+none
 
 #### Examples
 

--- a/app/pages/docs/cli-dev.mdx
+++ b/app/pages/docs/cli-dev.mdx
@@ -5,22 +5,16 @@ sidebar_label: blitz dev
 
 **Alias: `blitz d`**
 
-Starts the Blitz development server.
+Starts the Blitz **development** server.
 
 This is a super thin wrapper over Next CLI to improve environment variable
 loading.
 
-```bash
-blitz dev -e staging
-```
-
 It does the following:
 
-1. Loads correct `.env.X` and `.env.X.local` files based on the `-e X`
-   flag that you specify. Ex: `-e staging` loads `.env.staging`.
-2. Sets `process.env.APP_ENV` to the env name. Ex: `-e staging` =>
-   `APP_ENV=staging`.
-3. Passes all other arguments directly to the next build command
+1. Loads correct `.env.local`.
+2. Sets `process.env.APP_ENV` to the env `dev`.
+3. Passes all other arguments directly to the [`next dev` command](https://nextjs.org/docs/api-reference/cli#development)
 
 #### Options
 

--- a/app/pages/docs/cli-start.mdx
+++ b/app/pages/docs/cli-start.mdx
@@ -5,22 +5,16 @@ sidebar_label: blitz start
 
 **Alias: `blitz s`**
 
-Starts the Blitz production server.
+Starts the Blitz **production** server.
 
 This is a super thin wrapper over Next CLI to improve environment variable
 loading.
 
-```bash
-blitz dev -e staging
-```
-
 It does the following:
 
-1. Loads correct `.env.X` and `.env.X.local` files based on the `-e X`
-   flag that you specify. Ex: `-e staging` loads `.env.staging`.
-2. Sets `process.env.APP_ENV` to the env name. Ex: `-e staging` =>
-   `APP_ENV=staging`.
-3. Passes all other arguments directly to the next build command
+1. Loads correct `.env.production`.
+2. Sets `process.env.APP_ENV` to the env `production`.
+3. Passes all other arguments directly to the [`next start` command](https://nextjs.org/docs/api-reference/cli#production)
 
 #### Options
 


### PR DESCRIPTION
I was reading the blitz command docs and got confused by the part about the environment. All docs used `blitz dev -e staging` as the first big block of code. I think this was a copy paste error. I removed it as part of these changes.

Other changes:

## `blitz build`

- docs https://blitzjs.com/docs/cli-build
- code https://github.com/blitz-js/blitz/blob/main/packages/blitz/src/cli/commands/next/build.ts

The code hard codes the `env`. The docs now show that. They also reference the `--inspect` which is something the code allows.

## `blitz start`, `blitz dev`

- docs https://blitzjs.com/docs/cli-start
- code https://github.com/blitz-js/blitz/blob/main/packages/blitz/src/cli/commands/next/start.ts
- docs https://blitzjs.com/docs/cli-dev
- code https://github.com/blitz-js/blitz/blob/main/packages/blitz/src/cli/commands/next/dev.ts

Both commands are meant to run as production or development. Therefore the reference to change the environment is confusing – that is what the other command is there for.

The part I don't get is, why the code changes based on the `NODE_ENV` (https://github.com/blitz-js/blitz/blob/main/packages/blitz/src/cli/commands/next/dev.ts#L25 and https://github.com/blitz-js/blitz/blob/main/packages/blitz/src/cli/commands/next/start.ts#L25).

---

All pages now link to the next JS docs for the corresponding command.
