### PR TITLE
Update auth-config.mdx

### DIFF
--- a/app/pages/docs/auth-config.mdx
+++ b/app/pages/docs/auth-config.mdx
@@ -77,7 +77,8 @@ const { gSSP, gSP, api } = setupBlitzServer({
 export { gSSP, gSP, api }
 ```
 
-[**Here's a GitHub gist with a full Redis example.**](https://gist.github.com/beerose/80f37b4b36cbd7ba2745701959e3cb8b)
+[**Here's a GitHub gist with a full Redis example.**](https://gist.github.com/ShaharIlany/b0be76dae7caeace4cf23fb33d02e182)
+
 
 The storage methods need to conform to the following interface:
 


### PR DESCRIPTION
I've created a GitHub gist for using Redis to create a session storage.

My version includes fix for date parsing on `expiresAt` that causes an error on the current version.
Also I've used the TTL that is built into Redis - The usage of TTL eliminates the need of using cronjob. "For serious production apps, a cronjob is needed to remove all expired tokens on a regular basis."