### PR TITLE
Docs: Routes: Section on hash URLs

### DIFF
--- a/app/pages/docs/route-manifest.mdx
+++ b/app/pages/docs/route-manifest.mdx
@@ -46,3 +46,14 @@ your source code. Both [`blitz build`](./cli-build) and
 [`blitz dev`](./cli-dev) will automatically keep it up-to-date.  
 If you need to manually generate the route manifest (for example for a
 typecheck in CI) use [`blitz codegen`](./cli-codegen).
+
+## Using hash URLs
+
+To create a hash URL [follow the Next JS docs](https://nextjs.org/docs/pages/api-reference/components/link#with-url-object) and spread the route manifest to populate the `pathname` and `query` part of the URL object. This works for `useRouter()` with `router.push` as well as for the Next JS `Link` component.
+
+```tsx
+<Link href={{
+  ...Routes.Product({ pid, offerCode: "capybara" }), 
+  hash: 'yourHash'
+}} />
+```


### PR DESCRIPTION
This will add a section on https://blitzjs.com/docs/route-manifest#query-parameters that describes how to use Hash URLs with Blitz and Next JS.

See also Discord.