### PR TITLE
feat(docs): recommend formik and typescript by default

### DIFF
--- a/app/pages/docs/cli-new.mdx
+++ b/app/pages/docs/cli-new.mdx
@@ -23,18 +23,18 @@ name.
 
 #### Options
 
-| Argument         | Short | Description                                                                                                                                         | Default |
-| ---------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--template`     |       | Lets you choose a project's template. If omittied, it shows a prompt to choose the template. Options: `full`, `minimal`.                            | None    |
-| `--language`     |       | A new project's language. If omittied, it shows a prompt to choose the language. Options: `typescript`, `javascript`.                               | None    |
-| `--dry-run`      | `-d`  | Displays what files would be generated but does not write the files to disk.                                                                        | `false` |
-| `--no-git`       |       | Skips git repository creation.                                                                                                                      | `false` |
-| `--skip-upgrade` |       | Skip blitz upgrade if outdated.                                                                                                                     | `false` |
-| `--form`         |       | A form library for the full project. If omitted, it shows a prompt to choose the library. Options: `react-final-form`, `react-hook-form`, `formik`. | None    |
-| `--yarn`         |       | Use yarn as the package manager.                                                                                                                    | `false` |
-| `--npm`          |       | Use npm as the package manager.                                                                                                                     | `false` |
-| `--pnpm`         |       | Use pnpm as the package manager.                                                                                                                    | `false` |
-| `--env`          | `-e`  | Set app environment name. [Read more](/docs/custom-environments#custom-environments).                                                               | None    |
+| Argument         | Short | Description                                                                                                                                         | Default      |
+| ---------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `--template`     |       | Lets you choose a project's template. If omittied, it shows a prompt to choose the template. Options: `full`, `minimal`.                            | None         |
+| `--language`     |       | A new project's language. If omittied, it shows a prompt to choose the language. Options: `typescript`.                                             | `typescript` |
+| `--dry-run`      | `-d`  | Displays what files would be generated but does not write the files to disk.                                                                        | `false`      |
+| `--no-git`       |       | Skips git repository creation.                                                                                                                      | `false`      |
+| `--skip-upgrade` |       | Skip blitz upgrade if outdated.                                                                                                                     | `false`      |
+| `--form`         |       | A form library for the full project. If omitted, it shows a prompt to choose the library. Options: `formik`, `react-final-form`, `react-hook-form`. | None         |
+| `--yarn`         |       | Use yarn as the package manager.                                                                                                                    | `false`      |
+| `--npm`          |       | Use npm as the package manager.                                                                                                                     | `false`      |
+| `--pnpm`         |       | Use pnpm as the package manager.                                                                                                                    | `false`      |
+| `--env`          | `-e`  | Set app environment name. [Read more](/docs/custom-environments#custom-environments).                                                               | None         |
 
 #### Examples
 

--- a/app/pages/docs/tutorial.mdx
+++ b/app/pages/docs/tutorial.mdx
@@ -30,7 +30,7 @@ blitz new my-blitz-app
 Blitz will create a `my-blitz-app` folder in your current folder. You will
 be asked how you want your new app to be. For this tutorial, select all
 the default values by only pressing **Enter** when asked (you'll create a
-Full Blitz app with TypeScript, npm and React Final Form).
+Full Blitz app with TypeScript, npm and Formik).
 
 Let’s look at what `blitz new` created:
 

--- a/app/pages/docs/utilities.mdx
+++ b/app/pages/docs/utilities.mdx
@@ -11,7 +11,7 @@ This utility function will validate input using a
 [`zod`](https://github.com/colinhacks/zod) schema, and format any errors
 to be usable with your form library.
 
-This is currently compatible with both React Final Form and Formik and any
+This is currently compatible with both Formik, React Final Form and any
 others with the same API.
 
 ### Example {#validate-zod-schema-example}
@@ -27,7 +27,7 @@ import {validateZodSchema} from 'blitz'
 
 ### API {#validate-zod-schema-api}
 
-```js
+```ts
 const validationFunction = validateZodSchema(MyZodSchema)
 ```
 
@@ -46,7 +46,7 @@ A validation function to pass to a Form component's `validate` prop. It
 accepts some values and returns an Promise or object containing any
 errors.
 
-```
+```ts
 (values: any, parserType?: "sync" | "async") =>  Promise<Object> | Object
 ```
 
@@ -62,7 +62,7 @@ errors.
 This utility function will take a ZodError and format it nicely to be
 usable with your form library.
 
-This is currently compatible with both React Final Form and Formik and any
+This is currently compatible with both Formik, React Final Form and any
 others with the same API.
 
 ### Example {#format-zod-error-example}


### PR DESCRIPTION
- As per [my comment](https://github.com/blitz-js/blitz/commit/022392c1238386b5262fd0d8191ac6581648c36b#r126858105) on a commit which went live with `v2.0.0-beta.33`, `formik` is the new recommended form library to use
- On the same commit, `javascript` was removed as an option for new Blitz projects

Both of these changes are also reflected in this PR: https://github.com/blitz-js/blitz/pull/4214