### PR TITLE
(docs): update next-auth docs

### DIFF
--- a/app/pages/docs/next-auth.mdx
+++ b/app/pages/docs/next-auth.mdx
@@ -13,7 +13,7 @@ gives you a lot more flexibility & control than NextAuth does
 ### 1. Add the NextAuth Adapter for `next.config.js` {#add-next-auth-adapter-next-config}
 
 ```ts
-const { withNextAuthAdapter } = require("@blitzjs/auth/next-auth")
+const { withNextAuthAdapter } = require("@blitzjs/auth")
 const { withBlitz } = require("@blitzjs/next")
 
 /**


### PR DESCRIPTION
After going through https://blitzjs.com/docs/next-auth#add-next-auth-adapter-next-config, found out that path doesn't exist, fixed it with this PR