### PR TITLE
Update usage-next-13.mdx: remove ".js" file ending

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -26,7 +26,7 @@ the following methods and hooks have been implemented to work in the new `app` d
 
 Add the new `use client` directive to the following files:
 
-1. `src/blitz-client.(ts|js)`
+1. `src/blitz-client.ts`
 2. All Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks.
 
 #### BlitzProvider {#blitz-provider}


### PR DESCRIPTION
My understanding is, that the current blitz version only generates .ts files anymore. We can clean this up a bit.