### PR TITLE
Update usage-next-13.mdx: Still use `authConfig`

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -43,11 +43,13 @@ import {AuthClientPlugin} from "@blitzjs/auth"
 import {setupBlitzClient} from "@blitzjs/next"
 import {BlitzRpcPlugin} from "@blitzjs/rpc"
 
+export const authConfig = {
+  cookiePrefix: "blitz-auth-with-next-app",
+}
+
 export const {withBlitz, BlitzProvider} = setupBlitzClient({
   plugins: [
-    AuthClientPlugin({
-      cookiePrefix: "web-cookie-prefix",
-    }),
+    AuthClientPlugin(authConfig),
     BlitzRpcPlugin({}),
   ],
 })

--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -36,16 +36,13 @@ This provider should wrap the app and should be placed at the `(root)/layout.ts`
 **Setup** 
 
 ```ts
-// src/blitz-client
+// src/blitz-client.ts
 
 "use client"
 import {AuthClientPlugin} from "@blitzjs/auth"
 import {setupBlitzClient} from "@blitzjs/next"
 import {BlitzRpcPlugin} from "@blitzjs/rpc"
-
-export const authConfig = {
-  cookiePrefix: "blitz-auth-with-next-app",
-}
+import { authConfig } from './blitz-auth-config'
 
 export const {withBlitz, BlitzProvider} = setupBlitzClient({
   plugins: [
@@ -53,13 +50,23 @@ export const {withBlitz, BlitzProvider} = setupBlitzClient({
     BlitzRpcPlugin({}),
   ],
 })
-
 ```
 
-**In root layout.(ts|js) file**
+The `authConfig` needs to be in a separate file that is imported in `blitz-client.ts` as well as `blitz-server.ts`:
+
+```ts
+// src/blitz-auth-config.ts
+import { AuthPluginClientOptions } from '@blitzjs/auth'
+
+export const authConfig: AuthPluginClientOptions = {
+  cookiePrefix: "blitz-auth-with-next-app",
+}
+```
+
+**In root layout.ts file**
 
 ```tsx
-// layout.ts
+// src/layout.ts
 import { BlitzProvider } from "src/blitz-client"
 
 export default function RootLayout({children}: {children: React.ReactNode}) {


### PR DESCRIPTION
This is how the auth docs show it (https://blitzjs.com/docs/blitz-auth-with-next#add-blitz-server) and I assume all blitz apps with auth are set up. It is confusing when the app router docs show it differently.

At least I assume that the blitz-server still needs to share the cookie name(?)