### PR TITLE
Update usage-next-13.mdx: Clarify `/src/app` folder

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -29,6 +29,10 @@ Add the new `use client` directive to the following files:
 1. `src/blitz-client.(ts|js)`
 2. All Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks.
 
+#### Migrate files to `src/app`
+
+The NextJS `/app` folder needs to be located at `/src/app` in order to work with BlitzJS. More on ["Project Organization and File Colocation"](https://nextjs.org/docs/app/building-your-application/routing/colocation#src-directory) in the NextJS docs.
+
 #### BlitzProvider {#blitz-provider}
 
 This provider should wrap the app and should be placed at the `(root)/layout.ts` file.

--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -29,9 +29,9 @@ Add the new `use client` directive to the following files:
 1. `src/blitz-client.(ts|js)`
 2. All Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks.
 
-#### Migrate files to `src/app`
+#### Recommendations
 
-The NextJS `/app` folder needs to be located at `/src/app` in order to work with BlitzJS. More on ["Project Organization and File Colocation"](https://nextjs.org/docs/app/building-your-application/routing/colocation#src-directory) in the NextJS docs.
+- For Blitz apps that have their pages at `/src/pages` it is recommended to colocate the app directory at `/src/app`. However, a root `/app` App directory is also supported. More on the new NextJS file structure at ["Project Organization and File Colocation"](https://nextjs.org/docs/app/building-your-application/routing/colocation#src-directory).
 
 #### BlitzProvider {#blitz-provider}
 


### PR DESCRIPTION
Update: I tested this again with my test app at https://github.com/FixMyBerlin/blitz-test and it turns out you can run the page in root `/app/*` and include from `/src/*`. 

I updated this PR to a recommendation, because I still think its better to use `/src/app` for all blitz apps that use `/src/pages`.