### PR TITLE
Update usage-next-13.mdx: `BlitzProvider` as client component

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -24,14 +24,13 @@ the following methods and hooks have been implemented to work in the new `app` d
 
 #### Required changes {#required-changes}
 
-Add the new `use client` directive to the following files:
+Add the new `use client` directive to **all** files in the include-tree below [`BlitzProvider`](https://blitzjs.com/docs/usage-next-13#blitz-provider), which is a client component.
 
-1. `src/blitz-client.(ts|js)`
-2. All Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks.
+This includes `src/blitz-client.(ts|js)` and all Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks or browser actions like `onClick` ([more in the NextJS Docs](https://nextjs.org/docs/app/building-your-application/rendering/client-components#using-client-components-in-nextjs)).
 
 #### BlitzProvider {#blitz-provider}
 
-This provider should wrap the app and should be placed at the `(root)/layout.ts` file.
+This client component is a provider that should wrap the app and should be placed at the `(root)/layout.ts` file. 
 
 **Setup** 
 
@@ -58,6 +57,8 @@ export const {withBlitz, BlitzProvider} = setupBlitzClient({
 
 ```tsx
 // layout.ts
+'use client'
+
 import { BlitzProvider } from "src/blitz-client"
 
 export default function RootLayout({children}: {children: React.ReactNode}) {


### PR DESCRIPTION
Theres is also the request for help at https://discord.com/channels/802917734999523368/1161576668863922176. 

See also https://github.com/blitz-js/blitz/issues/4232.

## Change

My understanding is, that `BlitzProvider` is a client component and the way I understand the app directory means that everything below in the include-tree needs to be a client component as well.

## Testcase

1. checkout https://github.com/FixMyBerlin/blitz-test/commits/blitzprovider-test which is the error case without the use client in the layout file that holds the blitzprovider
2. See error

**Error**
> Unhandled Runtime Error
Error: Unsupported Server Component type: undefined


<img width="976" alt="image" src="https://github.com/blitz-js/blitzjs.com/assets/111561/47b33657-67b5-4cc7-9838-a171cda9f71d">


