### PR TITLE
Update usage-next-13.mdx: Clarify that the API route need to stay in the pages folder

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -29,6 +29,10 @@ Add the new `use client` directive to the following files:
 1. `src/blitz-client.(ts|js)`
 2. All Files with usage of `useQuery`, `useInfiniteQuery`, `usePaginatedQuery`, `useMutation`, `Hydrate` and other React Query client side hooks.
 
+**What not to change:**
+
+`/pags/api/rpc/[[...blitz]].ts` stays in the `/pages` folder.
+
 #### BlitzProvider {#blitz-provider}
 
 This provider should wrap the app and should be placed at the `(root)/layout.ts` file.


### PR DESCRIPTION
The current migration guide https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#migrating-from-pages-to-app recommends 

>` pages/api/*` currently remain inside the pages directory.

I tried moving the existing files to the app directory but that fails. Likely because the new app/api directory works differently. However, in general there are app/api routes documented in https://nextjs.org/docs/app/building-your-application/routing/route-handlers so maybe with updated files we can migrate…