### PR TITLE
Docs usage-next-13.mdx: Add section on the new Metadata and reference invoke

### DIFF
--- a/app/pages/docs/usage-next-13.mdx
+++ b/app/pages/docs/usage-next-13.mdx
@@ -75,6 +75,19 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
   )
 }
 ```
+#### Metadata {#metadata}
+
+The app router requires a new way to set Metadata. Follow the [NextJS Documentation](https://nextjs.org/docs/app/building-your-application/optimizing/metadata). Thinks to rememeber for BlitzJS:
+
+* Layouts and pages need to be server components which means you might have to extract interface elements that use hooks or browser APIs into separate client components first.
+* Use the [`invoke` helper](blitz-rpc-invoke) to use the dynamic `function generateMetadata` with BlitJS queries. Example:
+  ```ts
+  export async function generateMetadata({ params }) {
+    const project = await invoke(getProject, { id: params.projectId })
+    return { title: project?.name }
+  }
+  export default function Page() {)
+  ```
 
 #### Blitz Auth {#blitz-auth}
 
@@ -181,7 +194,7 @@ await useAuthenticatedBlitzContext({
 
 The following method are to be used to invoke a resolver in a react server component
 
-##### Using `invoke`
+##### Using `invoke` {#blitz-rpc-invoke}
 
 Let's say there is a requirement to query a resolver in the `(root)/page.js` file to check the details of the curretn user
 
@@ -207,7 +220,7 @@ export const {... , invoke} = setupBlitzServer({
 **In a RSC Page or Layout**
 
 ```tsx
-import {invoke} from "src/blitz-server"
+import {} from "src/blitz-server"
 import getCurrentUser from "src/users/queries/getCurrentUser"
 ```
 


### PR DESCRIPTION
NextJS App directory changed the way Metadata is handled (again). And it turned out to be quite nice. However, it requires to buy into server components for the layout and pages level. And one has to learn about the `invoke` helper by Blitz.

This PR adds hints to the docs on this topic.