### PR TITLE
Update documentation for URL Params & Query

### DIFF
--- a/app/pages/docs/route-params-query.mdx
+++ b/app/pages/docs/route-params-query.mdx
@@ -11,7 +11,7 @@ for the current route as an object. The default parameter type is
 argument to narrow the parameters and types that are returned.
 
 ```tsx
-import { useParams } from "blitz"
+import { useParams } from "@blitzjs/next"
 
 const params = useParams()
 // ReturnType: Record<string, undefined | string | string[]>
@@ -31,7 +31,7 @@ const params = useParams("array")
 ```tsx
 // File: app/products/pages/products/[id].tsx
 // URL: /products/2
-import { useParams } from "blitz"
+import { useParams } from "@blitzjs/next"
 
 const params = useParams()
 // params = {id: "2"}
@@ -40,7 +40,7 @@ const params = useParams()
 ```tsx
 // File: app/pages/blog/[category]/[...slug].tsx
 // URL: /blog/tech/2020/1
-import { useParams } from "blitz"
+import { useParams } from "@blitzjs/next"
 
 const params = useParams()
 // params = {category: "tech", slug: ["2020", "1"]}
@@ -60,7 +60,7 @@ for the current route. The default return type is
 argument to cast the return type.
 
 ```tsx
-import { useParam } from "blitz"
+import { useParam } from "@blitzjs/next"
 
 const param = useParam("id")
 // ReturnType: undefined | string | string[]
@@ -80,7 +80,7 @@ const param = useParam("id", "array")
 ```tsx
 // File: app/locations/pages/locations/[id]/[[...zipcode]].tsx
 // URL: /locations/2/02137
-import { useParam } from "blitz"
+import { useParam } from "@blitzjs/next"
 
 const id = useParam("id", "number")
 // id = 2
@@ -91,7 +91,7 @@ const zipcodes = useParam("zipcode", "array")
 ```tsx
 // File: app/pages/blog/[slug].tsx
 // URL: /blog/hello-world
-import { useParam } from "blitz"
+import { useParam } from "@blitzjs/next"
 
 const slug = useParam("slug", "string")
 // slug = "hello-world"
@@ -106,7 +106,7 @@ pattern`?key1=value1&key2=value2`. Parameter type is always `string`.
 ```tsx
 // URL: /products?sort=asc&limit=10
 
-import { useRouterQuery } from "blitz"
+import { useRouterQuery } from "@blitzjs/next"
 
 const query = useRouterQuery()
 


### PR DESCRIPTION
These functions are no longer exported by the main `blitz` package but by `@blitzjs/next`.