### PR TITLE
chore(sidebar): Remove overlap with footer

### DIFF
--- a/app/core/layouts/SidebarLayout.js
+++ b/app/core/layouts/SidebarLayout.js
@@ -49,13 +49,13 @@ function Nav({nav, children, fallbackHref, toc}) {
     <div
       id="navWrapper"
       onClick={(e) => e.stopPropagation()}
-      className="h-full scrolling-touch lg:h-auto lg:block lg:sticky lg:bg-transparent overflow-hidden lg:top-18 bg-white dark:bg-purple-deep mr-24 lg:mr-0"
+      className="h-full mb-px scrolling-touch lg:h-auto lg:block lg:sticky lg:bg-transparent overflow-hidden lg:top-18 bg-white dark:bg-purple-deep mr-24 lg:mr-0"
     >
       <div className="absolute bg-gradient-to-b from-white dark:from-purple-deep h-12 lg:block pointer-events-none w-full z-10"></div>
       <nav
         id="nav"
         ref={scrollRef}
-        className="px-1 mb-px bg-white dark:bg-purple-deep font-medium text-base sm:px-3 xl:px-5 pb-10 lg:pb-16 sticky?lg:h-(screen-18) lg:overflow-y-auto"
+        className="px-1 bg-white dark:bg-purple-deep font-medium text-base sm:px-3 xl:px-5 pb-10 lg:pb-16 sticky?lg:h-(screen-18) lg:overflow-y-auto"
       >
         <ul className="space-y-16 mt-10">
           {children}

--- a/app/core/layouts/SidebarLayout.js
+++ b/app/core/layouts/SidebarLayout.js
@@ -55,7 +55,7 @@ function Nav({nav, children, fallbackHref, toc}) {
       <nav
         id="nav"
         ref={scrollRef}
-        className="px-1 bg-white dark:bg-purple-deep font-medium text-base sm:px-3 xl:px-5 pb-10 lg:pb-16 sticky?lg:h-(screen-18) lg:overflow-y-auto"
+        className="px-1 mb-px bg-white dark:bg-purple-deep font-medium text-base sm:px-3 xl:px-5 pb-10 lg:pb-16 sticky?lg:h-(screen-18) lg:overflow-y-auto"
       >
         <ul className="space-y-16 mt-10">
           {children}


### PR DESCRIPTION
Currently the sidebar overlaps 1px with the footer, meaning the border is looking a bit weird. This fixes it.

| Before | After |
| --- | --- |
| ![CleanShot 2024-09-22 at 20 41 18](https://github.com/user-attachments/assets/fb627f17-4b27-4209-8c02-77c9a348b78f) | ![CleanShot 2024-09-22 at 20 42 13](https://github.com/user-attachments/assets/8bec5c57-f148-4503-81b9-c5a09ccc82b6) |
