### PR TITLE
fix: invalid route for rpc-config

### DIFF
--- a/app/pages/docs/rpc-setup.mdx
+++ b/app/pages/docs/rpc-setup.mdx
@@ -97,7 +97,7 @@ import { withBlitzAuth } from "app/blitz-server"
 export const { GET, POST, HEAD } = withBlitzAuth(rpcAppHandler())
 ```
 
-View [RPC Configurations](/rpc-config) to view the available options.
+View [RPC Configurations](/docs/rpc-config) to view the available options.
 
 #### Pages router: {#pages-router}
 
@@ -113,7 +113,7 @@ import { api } from "src/blitz-server"
 export default api(rpcHandler({}))
 ```
 
-View [RPC Configurations](/rpc-config) to view the available options.
+View [RPC Configurations](/docs/rpc-config) to view the available options.
 
 ---
 


### PR DESCRIPTION
fixes #866 

fixes wrong link from /rpc-config to /docs/rpc-config